### PR TITLE
Fix REPL: forward CLI sampling flags and recover from API errors

### DIFF
--- a/src/commands/chat.js
+++ b/src/commands/chat.js
@@ -78,6 +78,16 @@ async function imageToContent(value) {
   };
 }
 
+function applySamplingOptions(body, values) {
+  if (values.models) body.models = values.models.split(',').map((s) => s.trim());
+  if (values.temperature != null) body.temperature = Number(values.temperature);
+  if (values['top-p'] != null) body.top_p = Number(values['top-p']);
+  if (values['max-tokens'] != null) body.max_tokens = Number(values['max-tokens']);
+  if (values.seed != null) body.seed = Number(values.seed);
+  if (values.stop) body.stop = values.stop.split(',');
+  if (values.reasoning) body.reasoning = { effort: values.reasoning };
+}
+
 async function buildBody(values, prompt) {
   const messages = [];
   if (values.system) messages.push({ role: 'system', content: values.system });
@@ -98,12 +108,7 @@ async function buildBody(values, prompt) {
     model: values.model || 'openrouter/auto',
     messages
   };
-  if (values.models) body.models = values.models.split(',').map((s) => s.trim());
-  if (values.temperature != null) body.temperature = Number(values.temperature);
-  if (values['top-p'] != null) body.top_p = Number(values['top-p']);
-  if (values['max-tokens'] != null) body.max_tokens = Number(values['max-tokens']);
-  if (values.seed != null) body.seed = Number(values.seed);
-  if (values.stop) body.stop = values.stop.split(',');
+  applySamplingOptions(body, values);
 
   if (values['json-output']) body.response_format = { type: 'json_object' };
   if (values.schema) {
@@ -127,7 +132,6 @@ async function buildBody(values, prompt) {
     if (['auto', 'none', 'required'].includes(v)) body.tool_choice = v;
     else body.tool_choice = { type: 'function', function: { name: v } };
   }
-  if (values.reasoning) body.reasoning = { effort: values.reasoning };
   if (values.provider) body.provider = await loadJsonOrFile(values.provider);
   return body;
 }
@@ -286,6 +290,7 @@ async function repl(values, auth) {
       }
       history.push({ role: 'user', content: trimmed });
       const body = { model, messages: history, stream: true };
+      applySamplingOptions(body, values);
       try {
         const res = await api('POST', '/chat/completions', {
           auth,
@@ -300,11 +305,15 @@ async function repl(values, auth) {
             out(delta.content);
             assistant += delta.content;
           }
+          if (delta?.reasoning && process.stdout.isTTY) out(c.dim(delta.reasoning));
         }
         out('\n');
         history.push({ role: 'assistant', content: assistant });
       } catch (err) {
         outln(c.red(err.message));
+        // Drop the orphaned user message so the next turn doesn't send a
+        // [..., user, user] sequence the API will reject.
+        history.pop();
       }
     }
   } finally {


### PR DESCRIPTION
## Summary

The interactive REPL (`openrouter chat -i`) built its request body inline and silently ignored every sampling option from the parent `chat` command — `--temperature`, `--top-p`, `--max-tokens`, `--seed`, `--stop`, `--models`, `--reasoning`. It also corrupted its own history on any API error, requiring `/reset` to recover.

## Changes

- **`src/commands/chat.js`** — Extract `applySamplingOptions(body, values)` and call it in both `buildBody` (one-shot path) and the REPL turn loop, so flags work the same in either mode.
- **`src/commands/chat.js`** — Render `delta.reasoning` chunks in dim in the REPL, mirroring the one-shot streaming path, so `--reasoning low|medium|high` is actually visible.
- **`src/commands/chat.js`** — On API error in the REPL, pop the orphaned user message off `history` so the next turn doesn't send `[..., user, user]` (which providers reject) and the session stays usable without `/reset`.

Net diff: +16/-7 in one file. No new dependencies. Same one-shot semantics — `applySamplingOptions` produces identical output to the inline block it replaces.

## Context

Found while reading the codebase end-to-end. The two bugs are coupled — both stem from the REPL building its body inline rather than going through a shared helper — so the fix is a single small extraction plus a `history.pop()` in the catch block.

Verified with `node --check`, module load, and `chat --help` / `--version` smoke tests.

---
Built by [Aeon](https://github.com/aaronjmars/aeon-aaron)