### PR TITLE
feat: expose top-k, frequency/presence/repetition-penalty, min-p on chat

### DIFF
--- a/src/commands/chat.js
+++ b/src/commands/chat.js
@@ -17,9 +17,14 @@ Options:
       --no-stream          Disable streaming
       --temperature <n>
       --top-p <n>
+      --top-k <n>
       --max-tokens <n>
       --seed <n>
       --stop <text>        Stop sequence (repeatable via comma)
+      --frequency-penalty <n>   -2.0 to 2.0
+      --presence-penalty <n>    -2.0 to 2.0
+      --repetition-penalty <n>  0.0 to 2.0
+      --min-p <n>               0.0 to 1.0
       --json-output        Ask the model for JSON (response_format=json_object)
       --schema <file|json> JSON schema for structured output
       --tool <file|json>   Tool definition (repeatable). JSON object or @file.json
@@ -82,9 +87,14 @@ function applySamplingOptions(body, values) {
   if (values.models) body.models = values.models.split(',').map((s) => s.trim());
   if (values.temperature != null) body.temperature = Number(values.temperature);
   if (values['top-p'] != null) body.top_p = Number(values['top-p']);
+  if (values['top-k'] != null) body.top_k = Number(values['top-k']);
   if (values['max-tokens'] != null) body.max_tokens = Number(values['max-tokens']);
   if (values.seed != null) body.seed = Number(values.seed);
   if (values.stop) body.stop = values.stop.split(',');
+  if (values['frequency-penalty'] != null) body.frequency_penalty = Number(values['frequency-penalty']);
+  if (values['presence-penalty'] != null) body.presence_penalty = Number(values['presence-penalty']);
+  if (values['repetition-penalty'] != null) body.repetition_penalty = Number(values['repetition-penalty']);
+  if (values['min-p'] != null) body.min_p = Number(values['min-p']);
   if (values.reasoning) body.reasoning = { effort: values.reasoning };
 }
 
@@ -184,9 +194,14 @@ export async function chatCommand(argv) {
     'no-stream': { type: 'boolean' },
     temperature: { type: 'string' },
     'top-p': { type: 'string' },
+    'top-k': { type: 'string' },
     'max-tokens': { type: 'string' },
     seed: { type: 'string' },
     stop: { type: 'string' },
+    'frequency-penalty': { type: 'string' },
+    'presence-penalty': { type: 'string' },
+    'repetition-penalty': { type: 'string' },
+    'min-p': { type: 'string' },
     'json-output': { type: 'boolean' },
     schema: { type: 'string' },
     tool: { type: 'string', multiple: true },


### PR DESCRIPTION
## Summary

Adds the rest of OpenRouter's universal sampling parameters to `openrouter chat` (and its `complete` alias). They flow through both the one-shot path and the interactive REPL, since `applySamplingOptions` is reused on every REPL turn.

## Changes

`src/commands/chat.js` — 5 new kebab-flags wired through the existing pattern:

| flag | body field | range |
| --- | --- | --- |
| `--top-k <n>` | `top_k` | 1+ (0 = disabled on some providers) |
| `--frequency-penalty <n>` | `frequency_penalty` | -2.0 to 2.0 |
| `--presence-penalty <n>` | `presence_penalty` | -2.0 to 2.0 |
| `--repetition-penalty <n>` | `repetition_penalty` | 0.0 to 2.0 |
| `--min-p <n>` | `min_p` | 0.0 to 1.0 |

Omitted flags don't appear in the request body, so provider defaults still apply unchanged.

Verified with a fetch-monkeypatch soak test:
- All 5 new flags + existing 6 round-trip correctly to the snake_case API contract.
- Minimal call (`chat hi -m foo`) emits the exact same body it always did — no new fields leak in.

## Context

The CLI already exposes the OpenAI-shaped sampling subset (temperature, top-p, max-tokens, seed, stop, reasoning) but the rest of OpenRouter's universal-parameter set was missing — annoying when you're reproducing a CI smoke-test across the OpenAI / Anthropic / Mistral mix the router fans out to, where defaults differ. Same shape and indirection as the existing knobs, no new deps.

---
Built by [Aeon](https://github.com/aaronjmars/aeon-aaron)