### PR TITLE
fix: point default HTTP-Referer to the actual repo URL

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -318,7 +318,7 @@ openrouter --json keys get <hash> | jq '.data | {usage, usage_daily, limit_remai
 | --- | --- | --- |
 | `-k, --key` | `OPENROUTER_API_KEY` / `OPENROUTER_MANAGEMENT_KEY` | from config |
 | `--base-url` | `OPENROUTER_BASE_URL` | `https://openrouter.ai/api/v1` |
-| `--referer` | `OPENROUTER_REFERER` | `https://github.com/openrouter-cli` |
+| `--referer` | `OPENROUTER_REFERER` | `https://github.com/aaronjmars/openroutercli` |
 | `--title` | `OPENROUTER_TITLE` | `openrouter-cli` |
 | `--json` | — | off |
 | `-q, --quiet` | — | off |

--- a/src/config.js
+++ b/src/config.js
@@ -64,7 +64,7 @@ export async function resolveAuth(opts = {}) {
     opts.referer ||
     process.env.OPENROUTER_REFERER ||
     cfg.referer ||
-    'https://github.com/openrouter-cli';
+    'https://github.com/aaronjmars/openroutercli';
   const title =
     opts.title || process.env.OPENROUTER_TITLE || cfg.title || 'openrouter-cli';
   return {


### PR DESCRIPTION
## Summary
The hardcoded default for `HTTP-Referer` in `src/config.js` (and the matching row in `SKILL.md`'s configuration-reference table) points at `https://github.com/openrouter-cli` — a stray empty GitHub org with zero public repos, not the project's actual home. Anyone reviewing request attribution on the OpenRouter dashboard (which surfaces the Referer as a clickable link) lands on a dead page instead of the README / issues / installation instructions.

This swaps the default for `https://github.com/aaronjmars/openroutercli`, which matches `package.json#repository.url`, every README badge, and the npm page.

## Changes
- `src/config.js` — default `referer` (used by `resolveAuth` when no `--referer`, no `OPENROUTER_REFERER`, and no `cfg.referer` is set) now points at the real repo.
- `SKILL.md` — the configuration-reference table now documents the same default so agents reading the skill don't re-introduce the stale URL when teaching `--referer` usage.

## Context
Drift from the early `@aaronjmars/openrouter` → `@aaronjmars/openroutercli` rename trail (commits `368355a` / `c1ee192` / `246da00`): the package name was repointed at this repo, but the in-code default Referer URL was not. `gh api orgs/openrouter-cli/repos` returns `[]` — the URL leads nowhere.

User overrides (`--referer`, `OPENROUTER_REFERER`, `cfg.referer`) continue to win as before; this only changes the fallback. Verified `resolveAuth()` now returns `referer: https://github.com/aaronjmars/openroutercli` on a fresh config, and `openrouter --version` still loads cleanly.

---
Built by [Aeon](https://github.com/aaronjmars/aeon-aaron)
