### PR TITLE
ci: add GitHub Actions workflow (syntax + smoke + package checks)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Lint & smoke test (Node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [20, 22]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Syntax-check every tracked source file
+        run: |
+          set -euo pipefail
+          git ls-files '*.js' | while IFS= read -r f; do
+            echo "node --check $f"
+            node --check "$f"
+          done
+
+      - name: Smoke test — version resolves
+        run: |
+          set -euo pipefail
+          out="$(node bin/openrouter.js --version)"
+          echo "reported version: $out"
+          test -n "$out"
+
+      - name: Smoke test — help loads the full command graph
+        # `--help` imports every src/commands/* module via src/cli.js,
+        # so this fails on any broken import / ESM extension across the CLI.
+        run: node bin/openrouter.js --help > /dev/null
+
+      - name: Validate published package contents
+        run: npm pack --dry-run


### PR DESCRIPTION
## Summary
The repo had no CI. This adds a single `.github/workflows/ci.yml` that gates every push to `main` and every PR, so a syntax error, broken import, or packaging regression can't land on `main` unnoticed.

## Changes
- `.github/workflows/ci.yml` — one `check` job, Node `20` (the `engines` floor) and `22`:
  - **Syntax check** — `node --check` on every tracked `*.js` file.
  - **Smoke test** — `openrouter --version` resolves, and `openrouter --help` loads. The help path imports every `src/commands/*` module through `src/cli.js`, so it fails on any broken import or missing ESM `.js` extension anywhere in the CLI — real teeth without an API key.
  - **Package check** — `npm pack --dry-run` validates the published `files` set.

## Context
`MISSING_CI` was the top open opportunity on this repo. It's published to npm (`@aaronjmars/openroutercli`) as a global CLI, so a broken import shipping to users is the exact failure mode worth gating. Verified locally against current `main`: `node --check` clean across all 21 files, `--version` → `0.1.3`, `--help` exits 0, `npm pack --dry-run` lists 27 files cleanly. No deps/lockfile, so `npm ci` is intentionally omitted — the workflow needs no secrets or network and runs green on forks too.

---
Built by [Aeon](https://github.com/aaronjmars)
