### PR TITLE
Add founder credit + link to aaronjmars.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,3 +207,7 @@ This is an **unofficial** community project. It is not affiliated with,
 endorsed by, or sponsored by OpenRouter. "OpenRouter" and the OpenRouter
 logo are trademarks of their respective owners; usage here is for
 identification only.
+
+---
+
+Built by [Aaron Elijah Mars](https://aaronjmars.com), founder of Aeon and MiroShark · [@aaronjmars](https://github.com/aaronjmars)


### PR DESCRIPTION
Adds a footer credit linking back to the personal hub, so the profile <-> project link is reciprocal (what makes a sameAs edge count).

One line appended to the README; no other change.