### PR TITLE
chore: add Biome formatter (formatter only) + CI check

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,15 @@
+name: Format
+on:
+  push:
+    branches: [main]
+  pull_request:
+jobs:
+  biome:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - run: npm ci
+      - run: npm run format:check

--- a/bin/openrouter.js
+++ b/bin/openrouter.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
-import { run } from '../src/cli.js';
+import { run } from "../src/cli.js";
 
 run(process.argv.slice(2)).catch((err) => {
   const msg = err && err.message ? err.message : String(err);
   process.stderr.write(`error: ${msg}\n`);
   if (process.env.OPENROUTER_DEBUG && err && err.stack) {
-    process.stderr.write(err.stack + '\n');
+    process.stderr.write(err.stack + "\n");
   }
-  process.exit(err && typeof err.exitCode === 'number' ? err.exitCode : 1);
+  process.exit(err && typeof err.exitCode === "number" ? err.exitCode : 1);
 });

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.12/schema.json",
+  "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
+  "files": { "ignoreUnknown": true },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": { "enabled": false },
+  "assist": { "enabled": false },
+  "json": { "formatter": { "enabled": false } },
+  "css": { "formatter": { "enabled": false } }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@aaronjmars/openroutercli",
-  "version": "file:../../../../../../../private/var/folders/2_/vc1nr3rs5pl401hgx71swtxc0000gn/T/tmp.emgyg3pVco/openroutercli",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -19,7 +19,7 @@
         "node": ">=20"
       }
     },
-    "../../../../../../../private/var/folders/2_/vc1nr3rs5pl401hgx71swtxc0000gn/T/tmp.emgyg3pVco/openroutercli/node_modules/@biomejs/biome": {
+    "node_modules/@biomejs/biome": {
       "version": "2.5.12",
       "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.12.tgz",
       "integrity": "sha512-Lw4VHZRebrReBBnlHa12JQjnIBm3JJAA55PDB9LbBVBF0q4RYphm6KfmIjqtPhf61MxZ5Q9KoK8R8x+7per5Aw==",
@@ -46,7 +46,7 @@
         "@biomejs/cli-win32-x64": "2.5.12"
       }
     },
-    "../../../../../../../private/var/folders/2_/vc1nr3rs5pl401hgx71swtxc0000gn/T/tmp.emgyg3pVco/openroutercli/node_modules/@biomejs/cli-darwin-arm64": {
+    "node_modules/@biomejs/cli-darwin-arm64": {
       "version": "2.5.12",
       "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.12.tgz",
       "integrity": "sha512-lCRY1rwgNeWNgTr4DI/u6ZwXTRwRLHAvbaio1YLLGS+4r1nhvB2ssyPqIpfUSmRveNfv0fn/N58C7CAdK2XVrg==",
@@ -63,7 +63,7 @@
         "node": ">=14.21.3"
       }
     },
-    "../../../../../../../private/var/folders/2_/vc1nr3rs5pl401hgx71swtxc0000gn/T/tmp.emgyg3pVco/openroutercli/node_modules/@biomejs/cli-darwin-x64": {
+    "node_modules/@biomejs/cli-darwin-x64": {
       "version": "2.5.12",
       "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.12.tgz",
       "integrity": "sha512-vhPgwnh+6tN3ArdAXuET99xaNbFt7CG82Bqn+omHVLC5xdVx45JsYjGPmUIGNzjDek5XdNCP1HKksK7fn8+3bQ==",
@@ -80,7 +80,7 @@
         "node": ">=14.21.3"
       }
     },
-    "../../../../../../../private/var/folders/2_/vc1nr3rs5pl401hgx71swtxc0000gn/T/tmp.emgyg3pVco/openroutercli/node_modules/@biomejs/cli-linux-arm64": {
+    "node_modules/@biomejs/cli-linux-arm64": {
       "version": "2.5.12",
       "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.12.tgz",
       "integrity": "sha512-2gp8aVwXYKdAtmBfRFCUuyDMcfN1ahHqUkGfLYrZlNRFmryMATLVvJgWKvyA8wu4Rwn5OSxM1UcUmOuOFNGeBQ==",
@@ -100,7 +100,7 @@
         "node": ">=14.21.3"
       }
     },
-    "../../../../../../../private/var/folders/2_/vc1nr3rs5pl401hgx71swtxc0000gn/T/tmp.emgyg3pVco/openroutercli/node_modules/@biomejs/cli-linux-arm64-musl": {
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
       "version": "2.5.12",
       "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.12.tgz",
       "integrity": "sha512-couHYjFLL5uuI8ne6zhT7KwEsXo5YP7ry/2xmEqah7qanu0YmfDi3mwJg47YXSuv/NpZj22CZzcRH/5c4gjPSQ==",
@@ -120,7 +120,7 @@
         "node": ">=14.21.3"
       }
     },
-    "../../../../../../../private/var/folders/2_/vc1nr3rs5pl401hgx71swtxc0000gn/T/tmp.emgyg3pVco/openroutercli/node_modules/@biomejs/cli-linux-x64": {
+    "node_modules/@biomejs/cli-linux-x64": {
       "version": "2.5.12",
       "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.12.tgz",
       "integrity": "sha512-SnvOs3TSTiuia4SQOUNe1aWC9RT4+YkjcKnOhL/nsKOV0k5ycgBkDzF0lUxKn1V7Q8CLTRq6iV23ZAivHomRoA==",
@@ -140,7 +140,7 @@
         "node": ">=14.21.3"
       }
     },
-    "../../../../../../../private/var/folders/2_/vc1nr3rs5pl401hgx71swtxc0000gn/T/tmp.emgyg3pVco/openroutercli/node_modules/@biomejs/cli-linux-x64-musl": {
+    "node_modules/@biomejs/cli-linux-x64-musl": {
       "version": "2.5.12",
       "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.12.tgz",
       "integrity": "sha512-8A0oDW58/w9f/PQNYuq0sGUZtGtGrkNF4Z6n0PUoXpLCshi85vtKTv1XSznQawhdE4MXJ8ufpzHXyLFe87M/+w==",
@@ -160,7 +160,7 @@
         "node": ">=14.21.3"
       }
     },
-    "../../../../../../../private/var/folders/2_/vc1nr3rs5pl401hgx71swtxc0000gn/T/tmp.emgyg3pVco/openroutercli/node_modules/@biomejs/cli-win32-arm64": {
+    "node_modules/@biomejs/cli-win32-arm64": {
       "version": "2.5.12",
       "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.12.tgz",
       "integrity": "sha512-b9vtoZFsuZt1pdjNwJvXl0f+BpayRzV008uS2+JpmwIKdSE2qdu4A/l04FESwLoou5g2E/Qlec0xwJydZplH+A==",
@@ -177,7 +177,7 @@
         "node": ">=14.21.3"
       }
     },
-    "../../../../../../../private/var/folders/2_/vc1nr3rs5pl401hgx71swtxc0000gn/T/tmp.emgyg3pVco/openroutercli/node_modules/@biomejs/cli-win32-x64": {
+    "node_modules/@biomejs/cli-win32-x64": {
       "version": "2.5.12",
       "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.12.tgz",
       "integrity": "sha512-B1R/l+CwEpKFSuqiwePzPNRk1EiJN8kc0UhdafNz6MZN9v5OFP9HYP1irptvWzHrwVI4blVNGMbxc5zt70m3IA==",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,198 @@
+{
+  "name": "@aaronjmars/openroutercli",
+  "version": "file:../../../../../../../private/var/folders/2_/vc1nr3rs5pl401hgx71swtxc0000gn/T/tmp.emgyg3pVco/openroutercli",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@aaronjmars/openroutercli",
+      "version": "0.1.6",
+      "license": "MIT",
+      "bin": {
+        "openrouter": "bin/openrouter.js",
+        "or": "bin/openrouter.js"
+      },
+      "devDependencies": {
+        "@biomejs/biome": "^2.5.12"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "../../../../../../../private/var/folders/2_/vc1nr3rs5pl401hgx71swtxc0000gn/T/tmp.emgyg3pVco/openroutercli/node_modules/@biomejs/biome": {
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.12.tgz",
+      "integrity": "sha512-Lw4VHZRebrReBBnlHa12JQjnIBm3JJAA55PDB9LbBVBF0q4RYphm6KfmIjqtPhf61MxZ5Q9KoK8R8x+7per5Aw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.5.12",
+        "@biomejs/cli-darwin-x64": "2.5.12",
+        "@biomejs/cli-linux-arm64": "2.5.12",
+        "@biomejs/cli-linux-arm64-musl": "2.5.12",
+        "@biomejs/cli-linux-x64": "2.5.12",
+        "@biomejs/cli-linux-x64-musl": "2.5.12",
+        "@biomejs/cli-win32-arm64": "2.5.12",
+        "@biomejs/cli-win32-x64": "2.5.12"
+      }
+    },
+    "../../../../../../../private/var/folders/2_/vc1nr3rs5pl401hgx71swtxc0000gn/T/tmp.emgyg3pVco/openroutercli/node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.12.tgz",
+      "integrity": "sha512-lCRY1rwgNeWNgTr4DI/u6ZwXTRwRLHAvbaio1YLLGS+4r1nhvB2ssyPqIpfUSmRveNfv0fn/N58C7CAdK2XVrg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "../../../../../../../private/var/folders/2_/vc1nr3rs5pl401hgx71swtxc0000gn/T/tmp.emgyg3pVco/openroutercli/node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.12.tgz",
+      "integrity": "sha512-vhPgwnh+6tN3ArdAXuET99xaNbFt7CG82Bqn+omHVLC5xdVx45JsYjGPmUIGNzjDek5XdNCP1HKksK7fn8+3bQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "../../../../../../../private/var/folders/2_/vc1nr3rs5pl401hgx71swtxc0000gn/T/tmp.emgyg3pVco/openroutercli/node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.12.tgz",
+      "integrity": "sha512-2gp8aVwXYKdAtmBfRFCUuyDMcfN1ahHqUkGfLYrZlNRFmryMATLVvJgWKvyA8wu4Rwn5OSxM1UcUmOuOFNGeBQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "../../../../../../../private/var/folders/2_/vc1nr3rs5pl401hgx71swtxc0000gn/T/tmp.emgyg3pVco/openroutercli/node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.12.tgz",
+      "integrity": "sha512-couHYjFLL5uuI8ne6zhT7KwEsXo5YP7ry/2xmEqah7qanu0YmfDi3mwJg47YXSuv/NpZj22CZzcRH/5c4gjPSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "../../../../../../../private/var/folders/2_/vc1nr3rs5pl401hgx71swtxc0000gn/T/tmp.emgyg3pVco/openroutercli/node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.12.tgz",
+      "integrity": "sha512-SnvOs3TSTiuia4SQOUNe1aWC9RT4+YkjcKnOhL/nsKOV0k5ycgBkDzF0lUxKn1V7Q8CLTRq6iV23ZAivHomRoA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "../../../../../../../private/var/folders/2_/vc1nr3rs5pl401hgx71swtxc0000gn/T/tmp.emgyg3pVco/openroutercli/node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.12.tgz",
+      "integrity": "sha512-8A0oDW58/w9f/PQNYuq0sGUZtGtGrkNF4Z6n0PUoXpLCshi85vtKTv1XSznQawhdE4MXJ8ufpzHXyLFe87M/+w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "../../../../../../../private/var/folders/2_/vc1nr3rs5pl401hgx71swtxc0000gn/T/tmp.emgyg3pVco/openroutercli/node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.12.tgz",
+      "integrity": "sha512-b9vtoZFsuZt1pdjNwJvXl0f+BpayRzV008uS2+JpmwIKdSE2qdu4A/l04FESwLoou5g2E/Qlec0xwJydZplH+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "../../../../../../../private/var/folders/2_/vc1nr3rs5pl401hgx71swtxc0000gn/T/tmp.emgyg3pVco/openroutercli/node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.12.tgz",
+      "integrity": "sha512-B1R/l+CwEpKFSuqiwePzPNRk1EiJN8kc0UhdafNz6MZN9v5OFP9HYP1irptvWzHrwVI4blVNGMbxc5zt70m3IA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -50,6 +50,11 @@
     "access": "public"
   },
   "scripts": {
-    "start": "node bin/openrouter.js"
+    "start": "node bin/openrouter.js",
+    "format": "biome format --write .",
+    "format:check": "biome ci ."
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.5.12"
   }
 }

--- a/src/api.js
+++ b/src/api.js
@@ -1,9 +1,9 @@
-import { resolveAuth } from './config.js';
+import { resolveAuth } from "./config.js";
 
 export class APIError extends Error {
   constructor(message, { status, body } = {}) {
     super(message);
-    this.name = 'APIError';
+    this.name = "APIError";
     this.status = status;
     this.body = body;
     this.exitCode = 2;
@@ -12,9 +12,9 @@ export class APIError extends Error {
 
 function buildHeaders({ apiKey, referer, title, extra }) {
   const headers = {
-    Accept: 'application/json',
-    'HTTP-Referer': referer,
-    'X-Title': title
+    Accept: "application/json",
+    "HTTP-Referer": referer,
+    "X-Title": title,
   };
   if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
   return { ...headers, ...(extra || {}) };
@@ -22,7 +22,7 @@ function buildHeaders({ apiKey, referer, title, extra }) {
 
 function joinUrl(base, path) {
   if (/^https?:\/\//i.test(path)) return path;
-  return base.replace(/\/$/, '') + (path.startsWith('/') ? path : '/' + path);
+  return base.replace(/\/$/, "") + (path.startsWith("/") ? path : "/" + path);
 }
 
 async function parseError(res) {
@@ -33,10 +33,10 @@ async function parseError(res) {
   } catch {}
   const message =
     (body && body.error && body.error.message) ||
-    (typeof body === 'string' ? body : `HTTP ${res.status}`);
+    (typeof body === "string" ? body : `HTTP ${res.status}`);
   throw new APIError(`${res.status} ${res.statusText}: ${message}`, {
     status: res.status,
-    body
+    body,
   });
 }
 
@@ -46,28 +46,30 @@ export async function api(method, path, opts = {}) {
   const auth = await resolveAuth(authOpts);
   if (opts.requireAuth !== false && !auth.apiKey) {
     const msg = opts.requiresManagement
-      ? 'No API key set. This command needs a management key. Run `openrouter login --management` or set OPENROUTER_MANAGEMENT_KEY.'
-      : 'No API key set. Run `openrouter login` or `openrouter login --key sk-or-...`, or set OPENROUTER_API_KEY.';
+      ? "No API key set. This command needs a management key. Run `openrouter login --management` or set OPENROUTER_MANAGEMENT_KEY."
+      : "No API key set. Run `openrouter login` or `openrouter login --key sk-or-...`, or set OPENROUTER_API_KEY.";
     const e = new Error(msg);
     e.exitCode = 3;
     throw e;
   }
 
-  const url = joinUrl(auth.baseUrl, path) + (opts.query ? '?' + new URLSearchParams(opts.query).toString() : '');
+  const url =
+    joinUrl(auth.baseUrl, path) +
+    (opts.query ? "?" + new URLSearchParams(opts.query).toString() : "");
   const headers = buildHeaders({
     apiKey: auth.apiKey,
     referer: auth.referer,
     title: auth.title,
-    extra: opts.headers
+    extra: opts.headers,
   });
 
   let body;
   if (opts.body !== undefined) {
-    if (opts.body instanceof Uint8Array || typeof opts.body === 'string') {
+    if (opts.body instanceof Uint8Array || typeof opts.body === "string") {
       body = opts.body;
     } else {
       body = JSON.stringify(opts.body);
-      headers['Content-Type'] = 'application/json';
+      headers["Content-Type"] = "application/json";
     }
   }
 
@@ -75,7 +77,7 @@ export async function api(method, path, opts = {}) {
     method: method.toUpperCase(),
     headers,
     body,
-    signal: opts.signal
+    signal: opts.signal,
   });
 
   if (!res.ok) await parseError(res);
@@ -96,31 +98,30 @@ export async function api(method, path, opts = {}) {
 // non-2xx status, so nothing above this catches them.
 export function assertNoStreamError(evt) {
   if (!evt) return;
-  const err = evt.error ?? (evt.type === 'error' ? evt : null);
+  const err = evt.error ?? (evt.type === "error" ? evt : null);
   if (!err) return;
-  const message =
-    (typeof err === 'string' ? err : err.message) || JSON.stringify(err);
+  const message = (typeof err === "string" ? err : err.message) || JSON.stringify(err);
   throw new APIError(`stream error: ${message}`);
 }
 
 export async function* sseStream(res) {
   if (!res.body) return;
   const reader = res.body.getReader();
-  const decoder = new TextDecoder('utf8');
-  let buffer = '';
+  const decoder = new TextDecoder("utf8");
+  let buffer = "";
   while (true) {
     const { value, done } = await reader.read();
     if (done) break;
     buffer += decoder.decode(value, { stream: true });
     let idx;
-    while ((idx = buffer.indexOf('\n')) !== -1) {
-      const line = buffer.slice(0, idx).replace(/\r$/, '');
+    while ((idx = buffer.indexOf("\n")) !== -1) {
+      const line = buffer.slice(0, idx).replace(/\r$/, "");
       buffer = buffer.slice(idx + 1);
       if (!line) continue;
-      if (line.startsWith(':')) continue; // SSE comment / keepalive
-      if (line.startsWith('data:')) {
+      if (line.startsWith(":")) continue; // SSE comment / keepalive
+      if (line.startsWith("data:")) {
         const data = line.slice(5).trim();
-        if (data === '[DONE]') return;
+        if (data === "[DONE]") return;
         try {
           yield JSON.parse(data);
         } catch {

--- a/src/args.js
+++ b/src/args.js
@@ -1,15 +1,15 @@
-import { parseArgs as nodeParseArgs } from 'node:util';
-import { stdin } from 'node:process';
-import { isJsonMode } from './output.js';
+import { parseArgs as nodeParseArgs } from "node:util";
+import { stdin } from "node:process";
+import { isJsonMode } from "./output.js";
 
 const GLOBAL_OPTIONS = {
-  key: { type: 'string', short: 'k' },
-  'base-url': { type: 'string' },
-  referer: { type: 'string' },
-  title: { type: 'string' },
-  json: { type: 'boolean' },
-  quiet: { type: 'boolean', short: 'q' },
-  help: { type: 'boolean', short: 'h' }
+  key: { type: "string", short: "k" },
+  "base-url": { type: "string" },
+  referer: { type: "string" },
+  title: { type: "string" },
+  json: { type: "boolean" },
+  quiet: { type: "boolean", short: "q" },
+  help: { type: "boolean", short: "h" },
 };
 
 export function parseArgs(argv, options = {}) {
@@ -18,7 +18,7 @@ export function parseArgs(argv, options = {}) {
     args: argv,
     options: merged,
     allowPositionals: true,
-    strict: true
+    strict: true,
   });
 }
 
@@ -28,15 +28,15 @@ export function parseArgs(argv, options = {}) {
 export function numberOption(value, flag) {
   if (value === undefined) return undefined;
   const n = Number(value);
-  if (String(value).trim() === '' || !Number.isFinite(n)) {
+  if (String(value).trim() === "" || !Number.isFinite(n)) {
     throw new Error(`Invalid number for ${flag}: "${value}"`);
   }
   return n;
 }
 
 export const PAGINATION_OPTIONS = {
-  offset: { type: 'string' },
-  limit: { type: 'string' }
+  offset: { type: "string" },
+  limit: { type: "string" },
 };
 
 export function paginationQuery(values) {
@@ -49,7 +49,7 @@ export function paginationQuery(values) {
 export function authFromValues(values) {
   const out = {};
   if (values.key) out.key = values.key;
-  if (values['base-url']) out.baseUrl = values['base-url'];
+  if (values["base-url"]) out.baseUrl = values["base-url"];
   if (values.referer) out.referer = values.referer;
   if (values.title) out.title = values.title;
   return out;
@@ -57,14 +57,13 @@ export function authFromValues(values) {
 
 export async function readStdinIfPiped() {
   if (stdin.isTTY) return null;
-  let data = '';
+  let data = "";
   for await (const chunk of stdin) data += chunk;
   return data.trim() || null;
 }
 
 export function shouldStream(values) {
   return (
-    values.stream ||
-    (!values['no-stream'] && !values.raw && !isJsonMode() && process.stdout.isTTY)
+    values.stream || (!values["no-stream"] && !values.raw && !isJsonMode() && process.stdout.isTTY)
   );
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,26 +1,26 @@
-import { setJsonMode, setQuiet, outln } from './output.js';
-import { loginCommand, logoutCommand } from './commands/login.js';
-import { whoamiCommand, creditsCommand, activityCommand } from './commands/account.js';
-import { modelsCommand, providersCommand } from './commands/models.js';
-import { chatCommand, completeCommand } from './commands/chat.js';
-import { embedCommand } from './commands/embed.js';
-import { rerankCommand } from './commands/rerank.js';
-import { speechCommand } from './commands/speech.js';
-import { videoCommand } from './commands/video.js';
-import { messagesCommand, responsesCommand } from './commands/messages.js';
-import { generationCommand } from './commands/generation.js';
-import { keysCommand } from './commands/keys.js';
-import { requestCommand } from './commands/request.js';
-import { guardrailsCommand } from './commands/guardrails.js';
-import { workspacesCommand } from './commands/workspaces.js';
-import { orgCommand, zdrCommand, authCodeCommand } from './commands/misc.js';
-import { DEFAULT_BASE_URL } from './config.js';
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
+import { setJsonMode, setQuiet, outln } from "./output.js";
+import { loginCommand, logoutCommand } from "./commands/login.js";
+import { whoamiCommand, creditsCommand, activityCommand } from "./commands/account.js";
+import { modelsCommand, providersCommand } from "./commands/models.js";
+import { chatCommand, completeCommand } from "./commands/chat.js";
+import { embedCommand } from "./commands/embed.js";
+import { rerankCommand } from "./commands/rerank.js";
+import { speechCommand } from "./commands/speech.js";
+import { videoCommand } from "./commands/video.js";
+import { messagesCommand, responsesCommand } from "./commands/messages.js";
+import { generationCommand } from "./commands/generation.js";
+import { keysCommand } from "./commands/keys.js";
+import { requestCommand } from "./commands/request.js";
+import { guardrailsCommand } from "./commands/guardrails.js";
+import { workspacesCommand } from "./commands/workspaces.js";
+import { orgCommand, zdrCommand, authCodeCommand } from "./commands/misc.js";
+import { DEFAULT_BASE_URL } from "./config.js";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
 
-const pkgPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'package.json');
-const VERSION = JSON.parse(readFileSync(pkgPath, 'utf8')).version;
+const pkgPath = join(dirname(fileURLToPath(import.meta.url)), "..", "package.json");
+const VERSION = JSON.parse(readFileSync(pkgPath, "utf8")).version;
 
 const COMMANDS = {
   login: loginCommand,
@@ -45,8 +45,8 @@ const COMMANDS = {
   workspaces: workspacesCommand,
   org: orgCommand,
   zdr: zdrCommand,
-  'auth-code': authCodeCommand,
-  request: requestCommand
+  "auth-code": authCodeCommand,
+  request: requestCommand,
 };
 
 const HELP = `openrouter - CLI for the OpenRouter API
@@ -131,10 +131,10 @@ function preParseGlobals(argv) {
   let version = false;
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
-    if (a === '--json') json = true;
-    else if (a === '-q' || a === '--quiet') quiet = true;
-    else if (a === '-V' || a === '--version') version = true;
-    else if (a === '-h' || a === '--help') {
+    if (a === "--json") json = true;
+    else if (a === "-q" || a === "--quiet") quiet = true;
+    else if (a === "-V" || a === "--version") version = true;
+    else if (a === "-h" || a === "--help") {
       help = true;
       out.push(a); // forward so subcommand help can also pick it up
     } else out.push(a);
@@ -166,7 +166,7 @@ export async function run(argv) {
     return safeExit(1);
   }
   const code = await handler(rest);
-  if (typeof code === 'number') await safeExit(code);
+  if (typeof code === "number") await safeExit(code);
 }
 
 function safeExit(code) {
@@ -183,7 +183,7 @@ function safeExit(code) {
     for (const stream of [process.stdout, process.stderr]) {
       if (stream && stream.writableLength > 0) {
         pending++;
-        stream.write('', done);
+        stream.write("", done);
       }
     }
     if (pending === 0) {

--- a/src/commands/account.js
+++ b/src/commands/account.js
@@ -1,11 +1,11 @@
-import { parseArgs, authFromValues } from '../args.js';
-import { api, APIError } from '../api.js';
-import { resolveAuth } from '../config.js';
-import { c, isJsonMode, outln, printJSON, printResult, table } from '../output.js';
+import { parseArgs, authFromValues } from "../args.js";
+import { api, APIError } from "../api.js";
+import { resolveAuth } from "../config.js";
+import { c, isJsonMode, outln, printJSON, printResult, table } from "../output.js";
 
 async function fetchKey(authOpts, requiresManagement = false) {
   try {
-    return await api('GET', '/key', { auth: authOpts, requiresManagement });
+    return await api("GET", "/key", { auth: authOpts, requiresManagement });
   } catch (err) {
     if (err instanceof APIError) return { error: err.message };
     throw err;
@@ -15,41 +15,43 @@ async function fetchKey(authOpts, requiresManagement = false) {
 function renderKey(label, data) {
   outln(c.bold(label));
   if (!data) {
-    outln(c.dim('  (not configured)'));
+    outln(c.dim("  (not configured)"));
     return;
   }
   if (data.error) {
-    outln('  ' + c.red(data.error));
+    outln("  " + c.red(data.error));
     return;
   }
   const d = data.data || data;
-  outln(`  label:              ${d.label ?? ''}`);
+  outln(`  label:              ${d.label ?? ""}`);
   outln(`  is_management_key:  ${d.is_management_key ?? false}`);
   outln(`  is_free_tier:       ${d.is_free_tier}`);
-  outln(`  limit:              ${d.limit ?? 'unlimited'}`);
-  outln(`  limit_remaining:    ${d.limit_remaining ?? '-'}`);
-  outln(`  limit_reset:        ${d.limit_reset ?? '-'}`);
-  outln(`  usage (total):      ${d.usage ?? '-'}`);
+  outln(`  limit:              ${d.limit ?? "unlimited"}`);
+  outln(`  limit_remaining:    ${d.limit_remaining ?? "-"}`);
+  outln(`  limit_reset:        ${d.limit_reset ?? "-"}`);
+  outln(`  usage (total):      ${d.usage ?? "-"}`);
   if (d.usage_daily != null) outln(`  usage_daily:        ${d.usage_daily}`);
   if (d.usage_weekly != null) outln(`  usage_weekly:       ${d.usage_weekly}`);
   if (d.usage_monthly != null) outln(`  usage_monthly:      ${d.usage_monthly}`);
   if (d.byok_usage != null) outln(`  byok_usage:         ${d.byok_usage}`);
-  outln(`  expires_at:         ${d.expires_at ?? '-'}`);
+  outln(`  expires_at:         ${d.expires_at ?? "-"}`);
   if (d.rate_limit) {
-    outln(`  rate_limit:         ${d.rate_limit.requests ?? '?'} req / ${d.rate_limit.interval ?? '?'}`);
+    outln(
+      `  rate_limit:         ${d.rate_limit.requests ?? "?"} req / ${d.rate_limit.interval ?? "?"}`,
+    );
   }
 }
 
 export async function whoamiCommand(argv) {
   const { values } = parseArgs(argv, {
-    management: { type: 'boolean' }
+    management: { type: "boolean" },
   });
   if (values.help) {
     process.stdout.write(
-      'Usage: openrouter whoami [--management]\n\n' +
-        'Show the API key(s) currently configured. By default shows both the user\n' +
-        'key and the management key (if set). With --management, shows only the\n' +
-        'management key.\n'
+      "Usage: openrouter whoami [--management]\n\n" +
+        "Show the API key(s) currently configured. By default shows both the user\n" +
+        "key and the management key (if set). With --management, shows only the\n" +
+        "management key.\n",
     );
     return 0;
   }
@@ -59,17 +61,17 @@ export async function whoamiCommand(argv) {
 
   // If --key is supplied, query just that key.
   if (authOpts.key) {
-    const data = await api('GET', '/key', { auth: authOpts });
-    printResult(data, () => renderKey('API key (--key override)', data));
+    const data = await api("GET", "/key", { auth: authOpts });
+    printResult(data, () => renderKey("API key (--key override)", data));
     return 0;
   }
 
   if (values.management) {
     const data = resolved.hasManagementKey
-      ? await api('GET', '/key', { auth: authOpts, requiresManagement: true })
+      ? await api("GET", "/key", { auth: authOpts, requiresManagement: true })
       : null;
     if (isJsonMode()) printJSON({ management: data });
-    else renderKey('Management key', data);
+    else renderKey("Management key", data);
     return 0;
   }
 
@@ -85,22 +87,22 @@ export async function whoamiCommand(argv) {
     printJSON({ user: userData, management: mgmtData });
     return code;
   }
-  renderKey('User key', userData);
-  outln('');
-  renderKey('Management key', mgmtData);
+  renderKey("User key", userData);
+  outln("");
+  renderKey("Management key", mgmtData);
   return code;
 }
 
 export async function creditsCommand(argv) {
   const { values } = parseArgs(argv, {});
   if (values.help) {
-    process.stdout.write('Usage: openrouter credits\n\nShow remaining credits.\n');
+    process.stdout.write("Usage: openrouter credits\n\nShow remaining credits.\n");
     return 0;
   }
-  const data = await api('GET', '/credits', { auth: authFromValues(values) });
+  const data = await api("GET", "/credits", { auth: authFromValues(values) });
   printResult(data, () => {
     const d = data.data || data;
-    outln(c.bold('Credits'));
+    outln(c.bold("Credits"));
     for (const [k, v] of Object.entries(d)) outln(`  ${k}: ${v}`);
   });
   return 0;
@@ -108,37 +110,37 @@ export async function creditsCommand(argv) {
 
 export async function activityCommand(argv) {
   const { values } = parseArgs(argv, {
-    date: { type: 'string' },
-    'api-key-hash': { type: 'string' },
-    'user-id': { type: 'string' }
+    date: { type: "string" },
+    "api-key-hash": { type: "string" },
+    "user-id": { type: "string" },
   });
   if (values.help) {
     process.stdout.write(
-      `Usage: openrouter activity [options]\n\nGet usage activity grouped by endpoint.\n\nOptions:\n  --date <YYYY-MM-DD>     UTC date in last 30 days\n  --api-key-hash <hash>   Filter by API key SHA-256 hash\n  --user-id <id>          Filter by org member user ID\n`
+      `Usage: openrouter activity [options]\n\nGet usage activity grouped by endpoint.\n\nOptions:\n  --date <YYYY-MM-DD>     UTC date in last 30 days\n  --api-key-hash <hash>   Filter by API key SHA-256 hash\n  --user-id <id>          Filter by org member user ID\n`,
     );
     return 0;
   }
   const query = {};
   if (values.date) query.date = values.date;
-  if (values['api-key-hash']) query.api_key_hash = values['api-key-hash'];
-  if (values['user-id']) query.user_id = values['user-id'];
-  const data = await api('GET', '/activity', {
+  if (values["api-key-hash"]) query.api_key_hash = values["api-key-hash"];
+  if (values["user-id"]) query.user_id = values["user-id"];
+  const data = await api("GET", "/activity", {
     auth: authFromValues(values),
     requiresManagement: true,
-    query
+    query,
   });
   printResult(data, () => {
     const rows = data.data || [];
     if (!rows.length) {
-      outln(c.dim('(no activity)'));
+      outln(c.dim("(no activity)"));
       return;
     }
     table(rows, [
-      { label: 'date', value: (r) => r.date || r.day || '' },
-      { label: 'model', value: (r) => r.model || r.model_permaslug || '' },
-      { label: 'requests', value: (r) => r.requests ?? r.request_count ?? '' },
-      { label: 'tokens', value: (r) => r.tokens ?? r.total_tokens ?? '' },
-      { label: 'cost', value: (r) => r.usage ?? r.cost ?? '' }
+      { label: "date", value: (r) => r.date || r.day || "" },
+      { label: "model", value: (r) => r.model || r.model_permaslug || "" },
+      { label: "requests", value: (r) => r.requests ?? r.request_count ?? "" },
+      { label: "tokens", value: (r) => r.tokens ?? r.total_tokens ?? "" },
+      { label: "cost", value: (r) => r.usage ?? r.cost ?? "" },
     ]);
   });
   return 0;

--- a/src/commands/chat.js
+++ b/src/commands/chat.js
@@ -1,11 +1,11 @@
-import readline from 'node:readline/promises';
-import { stdin, stdout } from 'node:process';
-import { parseArgs, authFromValues, numberOption, shouldStream } from '../args.js';
-import { api, assertNoStreamError, sseStream } from '../api.js';
-import { c, info, isJsonMode, out, outln, printJSON } from '../output.js';
+import readline from "node:readline/promises";
+import { stdin, stdout } from "node:process";
+import { parseArgs, authFromValues, numberOption, shouldStream } from "../args.js";
+import { api, assertNoStreamError, sseStream } from "../api.js";
+import { c, info, isJsonMode, out, outln, printJSON } from "../output.js";
 
-const DEFAULT_MODEL = 'openrouter/auto';
-const ERROR_FINISH_REASONS = ['error', 'content_filter'];
+const DEFAULT_MODEL = "openrouter/auto";
+const ERROR_FINISH_REASONS = ["error", "content_filter"];
 
 const HELP = `Usage: openrouter chat [prompt...] [options]
 
@@ -45,22 +45,22 @@ Options:
 
 async function readStdinIfPiped() {
   if (stdin.isTTY) return null;
-  let data = '';
+  let data = "";
   for await (const chunk of stdin) data += chunk;
   return data.trimEnd() || null;
 }
 
 async function loadJsonOrFile(value) {
-  if (value.startsWith('@')) {
-    const { readFile } = await import('node:fs/promises');
-    const text = await readFile(value.slice(1), 'utf8');
+  if (value.startsWith("@")) {
+    const { readFile } = await import("node:fs/promises");
+    const text = await readFile(value.slice(1), "utf8");
     return JSON.parse(text);
   }
-  if (value.startsWith('{') || value.startsWith('[')) return JSON.parse(value);
+  if (value.startsWith("{") || value.startsWith("[")) return JSON.parse(value);
   // Bare value: try it as a file path first, then as inline JSON.
   try {
-    const { readFile } = await import('node:fs/promises');
-    const text = await readFile(value, 'utf8');
+    const { readFile } = await import("node:fs/promises");
+    const text = await readFile(value, "utf8");
     return JSON.parse(text);
   } catch {
     return JSON.parse(value);
@@ -68,45 +68,45 @@ async function loadJsonOrFile(value) {
 }
 
 async function imageToContent(value) {
-  if (/^https?:\/\//i.test(value) || value.startsWith('data:')) {
-    return { type: 'image_url', image_url: { url: value } };
+  if (/^https?:\/\//i.test(value) || value.startsWith("data:")) {
+    return { type: "image_url", image_url: { url: value } };
   }
-  const { readFile } = await import('node:fs/promises');
+  const { readFile } = await import("node:fs/promises");
   const buf = await readFile(value);
-  const ext = (value.split('.').pop() || '').toLowerCase();
+  const ext = (value.split(".").pop() || "").toLowerCase();
   const mime =
-    ext === 'png'
-      ? 'image/png'
-      : ext === 'webp'
-      ? 'image/webp'
-      : ext === 'gif'
-      ? 'image/gif'
-      : 'image/jpeg';
+    ext === "png"
+      ? "image/png"
+      : ext === "webp"
+        ? "image/webp"
+        : ext === "gif"
+          ? "image/gif"
+          : "image/jpeg";
   return {
-    type: 'image_url',
-    image_url: { url: `data:${mime};base64,${buf.toString('base64')}` }
+    type: "image_url",
+    image_url: { url: `data:${mime};base64,${buf.toString("base64")}` },
   };
 }
 
 const NUMERIC_SAMPLING = {
-  temperature: 'temperature',
-  'top-p': 'top_p',
-  'top-k': 'top_k',
-  'max-tokens': 'max_tokens',
-  seed: 'seed',
-  'frequency-penalty': 'frequency_penalty',
-  'presence-penalty': 'presence_penalty',
-  'repetition-penalty': 'repetition_penalty',
-  'min-p': 'min_p'
+  temperature: "temperature",
+  "top-p": "top_p",
+  "top-k": "top_k",
+  "max-tokens": "max_tokens",
+  seed: "seed",
+  "frequency-penalty": "frequency_penalty",
+  "presence-penalty": "presence_penalty",
+  "repetition-penalty": "repetition_penalty",
+  "min-p": "min_p",
 };
 
 function applySamplingOptions(body, values) {
-  if (values.models) body.models = values.models.split(',').map((s) => s.trim());
+  if (values.models) body.models = values.models.split(",").map((s) => s.trim());
   for (const [flag, field] of Object.entries(NUMERIC_SAMPLING)) {
     const n = numberOption(values[flag], `--${flag}`);
     if (n !== undefined) body[field] = n;
   }
-  if (values.stop) body.stop = values.stop.split(',');
+  if (values.stop) body.stop = values.stop.split(",");
   if (values.reasoning) body.reasoning = { effort: values.reasoning };
 }
 
@@ -114,7 +114,7 @@ async function buildUserContent(values, prompt, withImages) {
   const images = withImages ? values.image || [] : [];
   if (images.length === 0) return prompt;
   const parts = [];
-  if (prompt) parts.push({ type: 'text', text: prompt });
+  if (prompt) parts.push({ type: "text", text: prompt });
   for (const img of images) parts.push(await imageToContent(img));
   return parts;
 }
@@ -124,12 +124,12 @@ async function buildUserContent(values, prompt, withImages) {
 async function applyRequestOptions(body, values) {
   applySamplingOptions(body, values);
 
-  if (values['json-output']) body.response_format = { type: 'json_object' };
+  if (values["json-output"]) body.response_format = { type: "json_object" };
   if (values.schema) {
     const schema = await loadJsonOrFile(values.schema);
     body.response_format = {
-      type: 'json_schema',
-      json_schema: { name: 'response', schema, strict: true }
+      type: "json_schema",
+      json_schema: { name: "response", schema, strict: true },
     };
   }
   if (values.tool && values.tool.length) {
@@ -138,23 +138,23 @@ async function applyRequestOptions(body, values) {
       const def = await loadJsonOrFile(t);
       // Accept either {type, function} or a bare {name, parameters, ...}
       if (def.type && def.function) body.tools.push(def);
-      else body.tools.push({ type: 'function', function: def });
+      else body.tools.push({ type: "function", function: def });
     }
   }
-  if (values['tool-choice']) {
-    const v = values['tool-choice'];
-    if (['auto', 'none', 'required'].includes(v)) body.tool_choice = v;
-    else body.tool_choice = { type: 'function', function: { name: v } };
+  if (values["tool-choice"]) {
+    const v = values["tool-choice"];
+    if (["auto", "none", "required"].includes(v)) body.tool_choice = v;
+    else body.tool_choice = { type: "function", function: { name: v } };
   }
   if (values.provider) body.provider = await loadJsonOrFile(values.provider);
 }
 
 async function buildBody(values, prompt) {
   const messages = [];
-  if (values.system) messages.push({ role: 'system', content: values.system });
+  if (values.system) messages.push({ role: "system", content: values.system });
   messages.push({
-    role: 'user',
-    content: await buildUserContent(values, prompt, true)
+    role: "user",
+    content: await buildUserContent(values, prompt, true),
   });
   const body = { model: values.model || DEFAULT_MODEL, messages };
   await applyRequestOptions(body, values);
@@ -163,21 +163,21 @@ async function buildBody(values, prompt) {
 
 function printUsage(model, usage) {
   info(
-    `model=${model || ''} prompt=${usage.prompt_tokens} completion=${usage.completion_tokens} total=${usage.total_tokens}`
+    `model=${model || ""} prompt=${usage.prompt_tokens} completion=${usage.completion_tokens} total=${usage.total_tokens}`,
   );
 }
 
 async function streamResponse(body, auth) {
-  const res = await api('POST', '/chat/completions', {
+  const res = await api("POST", "/chat/completions", {
     auth,
     body: { ...body, stream: true },
     raw: true,
-    headers: { Accept: 'text/event-stream' }
+    headers: { Accept: "text/event-stream" },
   });
   let usage = null;
   let model = null;
   let finishReason = null;
-  let text = '';
+  let text = "";
   for await (const evt of sseStream(res)) {
     assertNoStreamError(evt);
     if (evt.usage) usage = evt.usage;
@@ -186,12 +186,12 @@ async function streamResponse(body, auth) {
     if (!choice) continue;
     const delta = choice.delta || choice.message;
     if (!delta) continue;
-    if (typeof delta.content === 'string') {
+    if (typeof delta.content === "string") {
       out(delta.content);
       text += delta.content;
     } else if (Array.isArray(delta.content)) {
       for (const part of delta.content) {
-        if (part.type === 'text' && part.text) {
+        if (part.type === "text" && part.text) {
           out(part.text);
           text += part.text;
         }
@@ -207,37 +207,37 @@ async function streamResponse(body, auth) {
     }
     if (choice.finish_reason) finishReason = choice.finish_reason;
   }
-  if (process.stdout.isTTY) out('\n');
+  if (process.stdout.isTTY) out("\n");
   return { usage, model, finishReason, text };
 }
 
 export async function chatCommand(argv) {
   const { values, positionals } = parseArgs(argv, {
-    model: { type: 'string', short: 'm' },
-    models: { type: 'string' },
-    system: { type: 'string', short: 's' },
-    stream: { type: 'boolean' },
-    'no-stream': { type: 'boolean' },
-    temperature: { type: 'string' },
-    'top-p': { type: 'string' },
-    'top-k': { type: 'string' },
-    'max-tokens': { type: 'string' },
-    seed: { type: 'string' },
-    stop: { type: 'string' },
-    'frequency-penalty': { type: 'string' },
-    'presence-penalty': { type: 'string' },
-    'repetition-penalty': { type: 'string' },
-    'min-p': { type: 'string' },
-    'json-output': { type: 'boolean' },
-    schema: { type: 'string' },
-    tool: { type: 'string', multiple: true },
-    'tool-choice': { type: 'string' },
-    reasoning: { type: 'string' },
-    provider: { type: 'string' },
-    image: { type: 'string', multiple: true },
-    raw: { type: 'boolean' },
-    usage: { type: 'boolean' },
-    interactive: { type: 'boolean', short: 'i' }
+    model: { type: "string", short: "m" },
+    models: { type: "string" },
+    system: { type: "string", short: "s" },
+    stream: { type: "boolean" },
+    "no-stream": { type: "boolean" },
+    temperature: { type: "string" },
+    "top-p": { type: "string" },
+    "top-k": { type: "string" },
+    "max-tokens": { type: "string" },
+    seed: { type: "string" },
+    stop: { type: "string" },
+    "frequency-penalty": { type: "string" },
+    "presence-penalty": { type: "string" },
+    "repetition-penalty": { type: "string" },
+    "min-p": { type: "string" },
+    "json-output": { type: "boolean" },
+    schema: { type: "string" },
+    tool: { type: "string", multiple: true },
+    "tool-choice": { type: "string" },
+    reasoning: { type: "string" },
+    provider: { type: "string" },
+    image: { type: "string", multiple: true },
+    raw: { type: "boolean" },
+    usage: { type: "boolean" },
+    interactive: { type: "boolean", short: "i" },
   });
 
   if (values.help) {
@@ -251,39 +251,37 @@ export async function chatCommand(argv) {
   // the REPL's readline with an exhausted stream and no way to report why.
   if (values.interactive && !stdin.isTTY) {
     throw new Error(
-      '--interactive needs a terminal on stdin. To send piped input as a ' +
-        'single prompt, drop -i: echo "hi" | openrouter chat'
+      "--interactive needs a terminal on stdin. To send piped input as a " +
+        'single prompt, drop -i: echo "hi" | openrouter chat',
     );
   }
 
   const piped = await readStdinIfPiped();
-  let prompt = positionals.join(' ').trim();
+  let prompt = positionals.join(" ").trim();
   if (piped) prompt = prompt ? `${prompt}\n\n${piped}` : piped;
 
-  const wantsInteractive =
-    values.interactive || (!prompt && stdin.isTTY && stdout.isTTY);
+  const wantsInteractive = values.interactive || (!prompt && stdin.isTTY && stdout.isTTY);
 
   if (wantsInteractive) {
     return repl(values, auth);
   }
 
   if (!prompt) {
-    throw new Error('No prompt. Pass text, pipe via stdin, or use --interactive.');
+    throw new Error("No prompt. Pass text, pipe via stdin, or use --interactive.");
   }
 
   const body = await buildBody(values, prompt);
 
   if (!shouldStream(values)) {
-    const data = await api('POST', '/chat/completions', { auth, body });
+    const data = await api("POST", "/chat/completions", { auth, body });
     if (isJsonMode() || values.raw) {
       printJSON(data);
     } else {
       const choice = data.choices && data.choices[0];
       const msg = choice && choice.message;
-      if (msg && typeof msg.content === 'string') outln(msg.content);
+      if (msg && typeof msg.content === "string") outln(msg.content);
       else if (msg && Array.isArray(msg.content)) {
-        for (const part of msg.content)
-          if (part.type === 'text') outln(part.text);
+        for (const part of msg.content) if (part.type === "text") outln(part.text);
       } else outln(JSON.stringify(data));
       if (values.usage && data.usage) printUsage(data.model, data.usage);
     }
@@ -307,8 +305,8 @@ export async function chatCommand(argv) {
 async function repl(values, auth) {
   const rl = readline.createInterface({ input: stdin, output: stdout });
   const history = [];
-  if (values.system) history.push({ role: 'system', content: values.system });
-  outln(c.dim('OpenRouter chat. /exit to quit, /reset to clear history, /model <id> to switch.'));
+  if (values.system) history.push({ role: "system", content: values.system });
+  outln(c.dim("OpenRouter chat. /exit to quit, /reset to clear history, /model <id> to switch."));
   let model = values.model || DEFAULT_MODEL;
   outln(c.dim(`model: ${model}`));
   let firstTurn = true;
@@ -316,23 +314,22 @@ async function repl(values, auth) {
     while (true) {
       let line;
       try {
-        line = await rl.question(c.cyan('› '));
+        line = await rl.question(c.cyan("› "));
       } catch {
         return 0;
       }
       if (line == null) return 0;
       const trimmed = line.trim();
       if (!trimmed) continue;
-      if (trimmed === '/exit' || trimmed === '/quit') return 0;
-      if (trimmed === '/reset') {
+      if (trimmed === "/exit" || trimmed === "/quit") return 0;
+      if (trimmed === "/reset") {
         history.length = 0;
-        if (values.system)
-          history.push({ role: 'system', content: values.system });
+        if (values.system) history.push({ role: "system", content: values.system });
         firstTurn = true;
-        outln(c.dim('(history cleared)'));
+        outln(c.dim("(history cleared)"));
         continue;
       }
-      if (trimmed.startsWith('/model ')) {
+      if (trimmed.startsWith("/model ")) {
         model = trimmed.slice(7).trim();
         outln(c.dim(`model: ${model}`));
         continue;
@@ -340,14 +337,14 @@ async function repl(values, auth) {
       // --image attaches to the opening turn only; resending it every turn
       // would re-upload the same attachment.
       history.push({
-        role: 'user',
-        content: await buildUserContent(values, trimmed, firstTurn)
+        role: "user",
+        content: await buildUserContent(values, trimmed, firstTurn),
       });
       const body = { model, messages: history };
       await applyRequestOptions(body, values);
       try {
         const meta = await streamResponse(body, auth);
-        history.push({ role: 'assistant', content: meta.text });
+        history.push({ role: "assistant", content: meta.text });
         firstTurn = false;
         if (values.usage && meta.usage) printUsage(meta.model, meta.usage);
         if (ERROR_FINISH_REASONS.includes(meta.finishReason)) {

--- a/src/commands/embed.js
+++ b/src/commands/embed.js
@@ -1,6 +1,6 @@
-import { parseArgs, authFromValues, numberOption, readStdinIfPiped } from '../args.js';
-import { api } from '../api.js';
-import { outln, pricePerMillion, printResult, table } from '../output.js';
+import { parseArgs, authFromValues, numberOption, readStdinIfPiped } from "../args.js";
+import { api } from "../api.js";
+import { outln, pricePerMillion, printResult, table } from "../output.js";
 
 const HELP = `Usage: openrouter embed [text...] [options]
        openrouter embed models
@@ -17,70 +17,75 @@ Options:
 `;
 
 export async function embedCommand(argv) {
-  if (argv[0] === 'models') {
+  if (argv[0] === "models") {
     const { values } = parseArgs(argv.slice(1), {});
     if (values.help) {
       process.stdout.write(HELP);
       return 0;
     }
-    const data = await api('GET', '/embeddings/models', {
+    const data = await api("GET", "/embeddings/models", {
       auth: authFromValues(values),
-      requireAuth: false
+      requireAuth: false,
     });
     printResult(data, () => {
       const rows = data.data || [];
       table(rows, [
-        { label: 'id', value: (m) => m.id },
-        { label: 'context', value: (m) => m.context_length ?? '' },
+        { label: "id", value: (m) => m.id },
+        { label: "context", value: (m) => m.context_length ?? "" },
         {
-          label: '$/M tokens',
-          value: (m) => pricePerMillion((m.pricing || {}).prompt)
+          label: "$/M tokens",
+          value: (m) => pricePerMillion((m.pricing || {}).prompt),
         },
-        { label: 'name', value: (m) => m.name || '' }
+        { label: "name", value: (m) => m.name || "" },
       ]);
     });
     return 0;
   }
 
   const { values, positionals } = parseArgs(argv, {
-    model: { type: 'string', short: 'm' },
-    input: { type: 'string', short: 'i', multiple: true },
-    'input-type': { type: 'string' },
-    dimensions: { type: 'string' },
-    encoding: { type: 'string' },
-    provider: { type: 'string' }
+    model: { type: "string", short: "m" },
+    input: { type: "string", short: "i", multiple: true },
+    "input-type": { type: "string" },
+    dimensions: { type: "string" },
+    encoding: { type: "string" },
+    provider: { type: "string" },
   });
   if (values.help) {
     process.stdout.write(HELP);
     return 0;
   }
-  if (!values.model) throw new Error('--model is required');
+  if (!values.model) throw new Error("--model is required");
 
   const inputs = [...(values.input || []), ...positionals];
   const piped = await readStdinIfPiped();
   if (piped) inputs.push(piped);
-  if (!inputs.length) throw new Error('No input. Pass text, use --input, or pipe stdin.');
+  if (!inputs.length) throw new Error("No input. Pass text, use --input, or pipe stdin.");
 
   const body = {
     model: values.model,
-    input: inputs.length === 1 ? inputs[0] : inputs
+    input: inputs.length === 1 ? inputs[0] : inputs,
   };
-  if (values['input-type']) body.input_type = values['input-type'];
-  if (values.dimensions) body.dimensions = numberOption(values.dimensions, '--dimensions');
+  if (values["input-type"]) body.input_type = values["input-type"];
+  if (values.dimensions) body.dimensions = numberOption(values.dimensions, "--dimensions");
   if (values.encoding) body.encoding_format = values.encoding;
   if (values.provider) body.provider = JSON.parse(values.provider);
 
-  const data = await api('POST', '/embeddings', {
+  const data = await api("POST", "/embeddings", {
     auth: authFromValues(values),
-    body
+    body,
   });
   printResult(data, () => {
     const arr = data.data || [];
     for (const e of arr) {
       const v = e.embedding;
       if (Array.isArray(v))
-        outln(`[${v.length}d] ${v.slice(0, 4).map((x) => x.toFixed(5)).join(', ')}, ...`);
-      else outln(String(v).slice(0, 80) + '...');
+        outln(
+          `[${v.length}d] ${v
+            .slice(0, 4)
+            .map((x) => x.toFixed(5))
+            .join(", ")}, ...`,
+        );
+      else outln(String(v).slice(0, 80) + "...");
     }
   });
   return 0;

--- a/src/commands/generation.js
+++ b/src/commands/generation.js
@@ -1,29 +1,29 @@
-import { parseArgs, authFromValues } from '../args.js';
-import { api } from '../api.js';
-import { c, outln, printResult } from '../output.js';
+import { parseArgs, authFromValues } from "../args.js";
+import { api } from "../api.js";
+import { c, outln, printResult } from "../output.js";
 
 export async function generationCommand(argv) {
   const { values, positionals } = parseArgs(argv, {
-    content: { type: 'boolean' }
+    content: { type: "boolean" },
   });
   if (values.help || !positionals[0]) {
     process.stdout.write(
-      'Usage: openrouter generation <id> [--content]\n\nFetch metadata for a generation. With --content, fetch the input/output content.\n'
+      "Usage: openrouter generation <id> [--content]\n\nFetch metadata for a generation. With --content, fetch the input/output content.\n",
     );
     return values.help ? 0 : 1;
   }
   const id = positionals[0];
-  const path = values.content ? '/generation/content' : '/generation';
-  const data = await api('GET', path, {
+  const path = values.content ? "/generation/content" : "/generation";
+  const data = await api("GET", path, {
     auth: authFromValues(values),
-    query: { id }
+    query: { id },
   });
   printResult(data, () => {
     const d = data.data || data;
     outln(c.bold(`generation ${id}`));
     for (const [k, v] of Object.entries(d)) {
-      const display = typeof v === 'string' && v.length > 200 ? v.slice(0, 200) + '...' : v;
-      outln(`  ${k}: ${typeof display === 'object' ? JSON.stringify(display) : display}`);
+      const display = typeof v === "string" && v.length > 200 ? v.slice(0, 200) + "..." : v;
+      outln(`  ${k}: ${typeof display === "object" ? JSON.stringify(display) : display}`);
     }
   });
   return 0;

--- a/src/commands/guardrails.js
+++ b/src/commands/guardrails.js
@@ -1,6 +1,12 @@
-import { parseArgs, authFromValues, PAGINATION_OPTIONS, paginationQuery, numberOption } from '../args.js';
-import { api } from '../api.js';
-import { outln, printResult, table } from '../output.js';
+import {
+  parseArgs,
+  authFromValues,
+  PAGINATION_OPTIONS,
+  paginationQuery,
+  numberOption,
+} from "../args.js";
+import { api } from "../api.js";
+import { outln, printResult, table } from "../output.js";
 
 const HELP = `Usage: openrouter guardrails <subcommand> [options]
 
@@ -35,192 +41,200 @@ create / update options:
 
 function csv(v) {
   if (v == null) return undefined;
-  if (v === '') return null;
-  return v.split(',').map((s) => s.trim()).filter(Boolean);
+  if (v === "") return null;
+  return v
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
 }
 
 function buildBody(values) {
   const body = {};
   if (values.description !== undefined) body.description = values.description;
-  if (values['limit-usd'] !== undefined) body.limit_usd = numberOption(values['limit-usd'], '--limit-usd');
-  if (values['reset-interval'] !== undefined) {
-    body.reset_interval = values['reset-interval'] === 'null' ? null : values['reset-interval'];
+  if (values["limit-usd"] !== undefined)
+    body.limit_usd = numberOption(values["limit-usd"], "--limit-usd");
+  if (values["reset-interval"] !== undefined) {
+    body.reset_interval = values["reset-interval"] === "null" ? null : values["reset-interval"];
   }
-  if (values['enforce-zdr']) body.enforce_zdr = true;
-  if (values['no-zdr']) body.enforce_zdr = false;
-  if (values['allowed-models'] !== undefined) body.allowed_models = csv(values['allowed-models']);
-  if (values['ignored-models'] !== undefined) body.ignored_models = csv(values['ignored-models']);
-  if (values['allowed-providers'] !== undefined) body.allowed_providers = csv(values['allowed-providers']);
-  if (values['ignored-providers'] !== undefined) body.ignored_providers = csv(values['ignored-providers']);
+  if (values["enforce-zdr"]) body.enforce_zdr = true;
+  if (values["no-zdr"]) body.enforce_zdr = false;
+  if (values["allowed-models"] !== undefined) body.allowed_models = csv(values["allowed-models"]);
+  if (values["ignored-models"] !== undefined) body.ignored_models = csv(values["ignored-models"]);
+  if (values["allowed-providers"] !== undefined)
+    body.allowed_providers = csv(values["allowed-providers"]);
+  if (values["ignored-providers"] !== undefined)
+    body.ignored_providers = csv(values["ignored-providers"]);
   return body;
 }
 
 const COMMON_FIELDS = {
-  description: { type: 'string' },
-  'limit-usd': { type: 'string' },
-  'reset-interval': { type: 'string' },
-  'enforce-zdr': { type: 'boolean' },
-  'no-zdr': { type: 'boolean' },
-  'allowed-models': { type: 'string' },
-  'ignored-models': { type: 'string' },
-  'allowed-providers': { type: 'string' },
-  'ignored-providers': { type: 'string' }
+  description: { type: "string" },
+  "limit-usd": { type: "string" },
+  "reset-interval": { type: "string" },
+  "enforce-zdr": { type: "boolean" },
+  "no-zdr": { type: "boolean" },
+  "allowed-models": { type: "string" },
+  "ignored-models": { type: "string" },
+  "allowed-providers": { type: "string" },
+  "ignored-providers": { type: "string" },
 };
 
 export async function guardrailsCommand(argv) {
   const sub = argv[0];
   const rest = argv.slice(1);
-  if (!sub || sub === 'help' || sub === '-h' || sub === '--help') {
+  if (!sub || sub === "help" || sub === "-h" || sub === "--help") {
     process.stdout.write(HELP);
     return sub ? 0 : 1;
   }
 
-  if (rest.includes('-h') || rest.includes('--help')) {
+  if (rest.includes("-h") || rest.includes("--help")) {
     process.stdout.write(HELP);
     return 0;
   }
 
-  if (sub === 'list') {
+  if (sub === "list") {
     const { values } = parseArgs(rest, PAGINATION_OPTIONS);
     const query = paginationQuery(values);
-    const data = await api('GET', '/guardrails', {
+    const data = await api("GET", "/guardrails", {
       auth: authFromValues(values),
       requiresManagement: true,
-      query
+      query,
     });
     printResult(data, () => {
       const rows = data.data || [];
       table(rows, [
-        { label: 'id', value: (g) => g.id },
-        { label: 'name', value: (g) => g.name },
-        { label: 'limit_usd', value: (g) => g.limit_usd ?? '' },
-        { label: 'reset', value: (g) => g.reset_interval ?? '' },
-        { label: 'zdr', value: (g) => (g.enforce_zdr ? 'yes' : '') }
+        { label: "id", value: (g) => g.id },
+        { label: "name", value: (g) => g.name },
+        { label: "limit_usd", value: (g) => g.limit_usd ?? "" },
+        { label: "reset", value: (g) => g.reset_interval ?? "" },
+        { label: "zdr", value: (g) => (g.enforce_zdr ? "yes" : "") },
       ]);
     });
     return 0;
   }
 
-  if (sub === 'get') {
+  if (sub === "get") {
     const { values, positionals } = parseArgs(rest, {});
-    if (!positionals[0]) throw new Error('id required');
-    const data = await api('GET', `/guardrails/${encodeURIComponent(positionals[0])}`, {
+    if (!positionals[0]) throw new Error("id required");
+    const data = await api("GET", `/guardrails/${encodeURIComponent(positionals[0])}`, {
       auth: authFromValues(values),
-      requiresManagement: true
+      requiresManagement: true,
     });
     printResult(data);
     return 0;
   }
 
-  if (sub === 'create') {
+  if (sub === "create") {
     const { values, positionals } = parseArgs(rest, {
       ...COMMON_FIELDS,
-      workspace: { type: 'string' }
+      workspace: { type: "string" },
     });
     const name = positionals[0];
-    if (!name) throw new Error('name required');
+    if (!name) throw new Error("name required");
     const body = { name, ...buildBody(values) };
     if (values.workspace) body.workspace_id = values.workspace;
-    const data = await api('POST', '/guardrails', {
+    const data = await api("POST", "/guardrails", {
       auth: authFromValues(values),
       requiresManagement: true,
-      body
+      body,
     });
     printResult(data);
     return 0;
   }
 
-  if (sub === 'update') {
+  if (sub === "update") {
     const { values, positionals } = parseArgs(rest, {
       ...COMMON_FIELDS,
-      name: { type: 'string' }
+      name: { type: "string" },
     });
-    if (!positionals[0]) throw new Error('id required');
+    if (!positionals[0]) throw new Error("id required");
     const body = buildBody(values);
     if (values.name) body.name = values.name;
-    const data = await api('PATCH', `/guardrails/${encodeURIComponent(positionals[0])}`, {
+    const data = await api("PATCH", `/guardrails/${encodeURIComponent(positionals[0])}`, {
       auth: authFromValues(values),
       requiresManagement: true,
-      body
+      body,
     });
     printResult(data);
     return 0;
   }
 
-  if (sub === 'delete') {
+  if (sub === "delete") {
     const { values, positionals } = parseArgs(rest, {});
-    if (!positionals[0]) throw new Error('id required');
-    const data = await api('DELETE', `/guardrails/${encodeURIComponent(positionals[0])}`, {
+    if (!positionals[0]) throw new Error("id required");
+    const data = await api("DELETE", `/guardrails/${encodeURIComponent(positionals[0])}`, {
       auth: authFromValues(values),
-      requiresManagement: true
+      requiresManagement: true,
     });
-    printResult(data, () => outln('deleted'));
+    printResult(data, () => outln("deleted"));
     return 0;
   }
 
-  if (sub === 'assignments') {
+  if (sub === "assignments") {
     const { values } = parseArgs(rest, {
-      keys: { type: 'boolean' },
-      members: { type: 'boolean' }
+      keys: { type: "boolean" },
+      members: { type: "boolean" },
     });
     if (values.keys && values.members) {
-      throw new Error('Pass only one of --keys or --members.');
+      throw new Error("Pass only one of --keys or --members.");
     }
     const path = values.members
-      ? '/guardrails/assignments/members'
-      : '/guardrails/assignments/keys';
-    const data = await api('GET', path, {
+      ? "/guardrails/assignments/members"
+      : "/guardrails/assignments/keys";
+    const data = await api("GET", path, {
       auth: authFromValues(values),
-      requiresManagement: true
+      requiresManagement: true,
     });
     printResult(data);
     return 0;
   }
 
-  if (sub === 'key-assignments' || sub === 'member-assignments') {
+  if (sub === "key-assignments" || sub === "member-assignments") {
     const { values, positionals } = parseArgs(rest, {});
-    if (!positionals[0]) throw new Error('id required');
+    if (!positionals[0]) throw new Error("id required");
     const path =
-      sub === 'key-assignments'
+      sub === "key-assignments"
         ? `/guardrails/${encodeURIComponent(positionals[0])}/assignments/keys`
         : `/guardrails/${encodeURIComponent(positionals[0])}/assignments/members`;
-    const data = await api('GET', path, {
+    const data = await api("GET", path, {
       auth: authFromValues(values),
-      requiresManagement: true
+      requiresManagement: true,
     });
     printResult(data);
     return 0;
   }
 
-  if (sub === 'assign-key' || sub === 'unassign-key') {
+  if (sub === "assign-key" || sub === "unassign-key") {
     const { values, positionals } = parseArgs(rest, {});
-    if (positionals.length < 2) throw new Error('Usage: <id> <hash>...');
+    if (positionals.length < 2) throw new Error("Usage: <id> <hash>...");
     const id = positionals[0];
     const hashes = positionals.slice(1);
-    const path = sub === 'assign-key'
-      ? `/guardrails/${encodeURIComponent(id)}/assignments/keys`
-      : `/guardrails/${encodeURIComponent(id)}/assignments/keys/remove`;
-    const data = await api('POST', path, {
+    const path =
+      sub === "assign-key"
+        ? `/guardrails/${encodeURIComponent(id)}/assignments/keys`
+        : `/guardrails/${encodeURIComponent(id)}/assignments/keys/remove`;
+    const data = await api("POST", path, {
       auth: authFromValues(values),
       requiresManagement: true,
-      body: { key_hashes: hashes }
+      body: { key_hashes: hashes },
     });
     printResult(data);
     return 0;
   }
 
-  if (sub === 'assign-member' || sub === 'unassign-member') {
+  if (sub === "assign-member" || sub === "unassign-member") {
     const { values, positionals } = parseArgs(rest, {});
-    if (positionals.length < 2) throw new Error('Usage: <id> <user_id>...');
+    if (positionals.length < 2) throw new Error("Usage: <id> <user_id>...");
     const id = positionals[0];
     const userIds = positionals.slice(1);
-    const path = sub === 'assign-member'
-      ? `/guardrails/${encodeURIComponent(id)}/assignments/members`
-      : `/guardrails/${encodeURIComponent(id)}/assignments/members/remove`;
-    const data = await api('POST', path, {
+    const path =
+      sub === "assign-member"
+        ? `/guardrails/${encodeURIComponent(id)}/assignments/members`
+        : `/guardrails/${encodeURIComponent(id)}/assignments/members/remove`;
+    const data = await api("POST", path, {
       auth: authFromValues(values),
       requiresManagement: true,
-      body: { user_ids: userIds }
+      body: { user_ids: userIds },
     });
     printResult(data);
     return 0;

--- a/src/commands/keys.js
+++ b/src/commands/keys.js
@@ -1,6 +1,6 @@
-import { parseArgs, authFromValues, numberOption } from '../args.js';
-import { api } from '../api.js';
-import { c, outln, printResult, table } from '../output.js';
+import { parseArgs, authFromValues, numberOption } from "../args.js";
+import { api } from "../api.js";
+import { c, outln, printResult, table } from "../output.js";
 
 const HELP = `Usage: openrouter keys <subcommand> [options]
 
@@ -35,120 +35,120 @@ update options:
 export async function keysCommand(argv) {
   const sub = argv[0];
   const rest = argv.slice(1);
-  if (!sub || sub === '-h' || sub === '--help' || sub === 'help') {
+  if (!sub || sub === "-h" || sub === "--help" || sub === "help") {
     process.stdout.write(HELP);
     return sub ? 0 : 1;
   }
 
-  if (rest.includes('-h') || rest.includes('--help')) {
+  if (rest.includes("-h") || rest.includes("--help")) {
     process.stdout.write(HELP);
     return 0;
   }
 
-  if (sub === 'list') {
+  if (sub === "list") {
     const { values } = parseArgs(rest, {
-      offset: { type: 'string' },
-      'include-disabled': { type: 'boolean' }
+      offset: { type: "string" },
+      "include-disabled": { type: "boolean" },
     });
     const query = {};
     if (values.offset) query.offset = values.offset;
-    if (values['include-disabled']) query.include_disabled = 'true';
-    const data = await api('GET', '/keys', {
+    if (values["include-disabled"]) query.include_disabled = "true";
+    const data = await api("GET", "/keys", {
       auth: authFromValues(values),
       requiresManagement: true,
-      query
+      query,
     });
     printResult(data, () => {
       const rows = data.data || [];
       table(rows, [
-        { label: 'name', value: (k) => k.name || '' },
-        { label: 'hash', value: (k) => k.hash || k.id || '' },
-        { label: 'usage', value: (k) => k.usage ?? '' },
-        { label: 'limit', value: (k) => k.limit ?? '' },
-        { label: 'disabled', value: (k) => (k.disabled ? 'yes' : '') }
+        { label: "name", value: (k) => k.name || "" },
+        { label: "hash", value: (k) => k.hash || k.id || "" },
+        { label: "usage", value: (k) => k.usage ?? "" },
+        { label: "limit", value: (k) => k.limit ?? "" },
+        { label: "disabled", value: (k) => (k.disabled ? "yes" : "") },
       ]);
     });
     return 0;
   }
 
-  if (sub === 'get') {
+  if (sub === "get") {
     const { values, positionals } = parseArgs(rest, {});
-    if (!positionals[0]) throw new Error('hash required');
-    const data = await api('GET', `/keys/${encodeURIComponent(positionals[0])}`, {
+    if (!positionals[0]) throw new Error("hash required");
+    const data = await api("GET", `/keys/${encodeURIComponent(positionals[0])}`, {
       auth: authFromValues(values),
-      requiresManagement: true
+      requiresManagement: true,
     });
     printResult(data);
     return 0;
   }
 
-  if (sub === 'create') {
+  if (sub === "create") {
     const { values, positionals } = parseArgs(rest, {
-      limit: { type: 'string' },
-      'limit-reset': { type: 'string' },
-      'expires-at': { type: 'string' },
-      workspace: { type: 'string' },
-      'include-byok': { type: 'boolean' }
+      limit: { type: "string" },
+      "limit-reset": { type: "string" },
+      "expires-at": { type: "string" },
+      workspace: { type: "string" },
+      "include-byok": { type: "boolean" },
     });
     const name = positionals[0];
-    if (!name) throw new Error('name required');
+    if (!name) throw new Error("name required");
     const body = { name };
-    if (values.limit) body.limit = numberOption(values.limit, '--limit');
-    if (values['limit-reset']) body.limit_reset = values['limit-reset'];
-    if (values['expires-at']) body.expires_at = values['expires-at'];
+    if (values.limit) body.limit = numberOption(values.limit, "--limit");
+    if (values["limit-reset"]) body.limit_reset = values["limit-reset"];
+    if (values["expires-at"]) body.expires_at = values["expires-at"];
     if (values.workspace) body.workspace_id = values.workspace;
-    if (values['include-byok']) body.include_byok_in_limit = true;
-    const data = await api('POST', '/keys', {
+    if (values["include-byok"]) body.include_byok_in_limit = true;
+    const data = await api("POST", "/keys", {
       auth: authFromValues(values),
       requiresManagement: true,
-      body
+      body,
     });
     printResult(data, () => {
       const k = data.key || (data.data && data.data.key);
       const meta = data.data || data;
-      outln(c.bold('key (save this - shown only once):'));
-      outln('  ' + (k || '(see JSON)'));
+      outln(c.bold("key (save this - shown only once):"));
+      outln("  " + (k || "(see JSON)"));
       outln(c.dim(JSON.stringify(meta, null, 2)));
     });
     return 0;
   }
 
-  if (sub === 'update') {
+  if (sub === "update") {
     const { values, positionals } = parseArgs(rest, {
-      name: { type: 'string' },
-      limit: { type: 'string' },
-      'limit-reset': { type: 'string' },
-      'include-byok': { type: 'boolean' },
-      'no-include-byok': { type: 'boolean' },
-      disabled: { type: 'boolean' },
-      enabled: { type: 'boolean' }
+      name: { type: "string" },
+      limit: { type: "string" },
+      "limit-reset": { type: "string" },
+      "include-byok": { type: "boolean" },
+      "no-include-byok": { type: "boolean" },
+      disabled: { type: "boolean" },
+      enabled: { type: "boolean" },
     });
-    if (!positionals[0]) throw new Error('hash required');
+    if (!positionals[0]) throw new Error("hash required");
     const body = {};
     if (values.name) body.name = values.name;
-    if (values.limit) body.limit = numberOption(values.limit, '--limit');
-    if (values['limit-reset']) body.limit_reset = values['limit-reset'];
-    if (values['include-byok']) body.include_byok_in_limit = true;
-    if (values['no-include-byok']) body.include_byok_in_limit = false;
+    if (values.limit) body.limit = numberOption(values.limit, "--limit");
+    if (values["limit-reset"]) body.limit_reset = values["limit-reset"];
+    if (values["include-byok"]) body.include_byok_in_limit = true;
+    if (values["no-include-byok"]) body.include_byok_in_limit = false;
     if (values.disabled) body.disabled = true;
     if (values.enabled) body.disabled = false;
-    const data = await api('PATCH', `/keys/${encodeURIComponent(positionals[0])}`, {
+    const data = await api("PATCH", `/keys/${encodeURIComponent(positionals[0])}`, {
       auth: authFromValues(values),
       requiresManagement: true,
-      body
+      body,
     });
     printResult(data);
     return 0;
   }
 
-  if (sub === 'delete') {
+  if (sub === "delete") {
     const { values, positionals } = parseArgs(rest, {});
-    if (!positionals[0]) throw new Error('hash required');
-    const data = await api('DELETE', `/keys/${encodeURIComponent(positionals[0])}`, {
+    if (!positionals[0]) throw new Error("hash required");
+    const data = await api("DELETE", `/keys/${encodeURIComponent(positionals[0])}`, {
       auth: authFromValues(values),
-      requiresManagement: true
+      requiresManagement: true,
     });
-    printResult(data, () => outln('deleted'));
+    printResult(data, () => outln("deleted"));
     return 0;
   }
 

--- a/src/commands/login.js
+++ b/src/commands/login.js
@@ -1,18 +1,18 @@
-import http from 'node:http';
-import crypto from 'node:crypto';
-import { spawn } from 'node:child_process';
-import readline from 'node:readline/promises';
-import { stdin, stdout } from 'node:process';
-import { parseArgs, numberOption } from '../args.js';
+import http from "node:http";
+import crypto from "node:crypto";
+import { spawn } from "node:child_process";
+import readline from "node:readline/promises";
+import { stdin, stdout } from "node:process";
+import { parseArgs, numberOption } from "../args.js";
 import {
   loadConfig,
   saveConfig,
   DEFAULT_AUTH_URL,
   DEFAULT_BASE_URL,
-  PROVISIONING_KEYS_URL
-} from '../config.js';
-import { api } from '../api.js';
-import { c, info, isJsonMode, outln, printJSON } from '../output.js';
+  PROVISIONING_KEYS_URL,
+} from "../config.js";
+import { api } from "../api.js";
+import { c, info, isJsonMode, outln, printJSON } from "../output.js";
 
 const HELP = `Usage: openrouter login [options]
 
@@ -49,29 +49,25 @@ Environment:
 
 function base64url(buf) {
   return Buffer.from(buf)
-    .toString('base64')
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=+$/, '');
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
 }
 
 function openBrowser(url) {
   const cmd =
-    process.platform === 'darwin'
-      ? 'open'
-      : process.platform === 'win32'
-      ? 'cmd'
-      : 'xdg-open';
-  const args = process.platform === 'win32' ? ['/c', 'start', '""', url] : [url];
-  const child = spawn(cmd, args, { detached: true, stdio: 'ignore' });
+    process.platform === "darwin" ? "open" : process.platform === "win32" ? "cmd" : "xdg-open";
+  const args = process.platform === "win32" ? ["/c", "start", '""', url] : [url];
+  const child = spawn(cmd, args, { detached: true, stdio: "ignore" });
   // Best effort: the URL is printed either way, and a missing launcher arrives
   // as an async 'error' event that would otherwise crash the process.
-  child.on('error', () => {});
+  child.on("error", () => {});
   child.unref();
 }
 
 async function readFromStdin() {
-  let data = '';
+  let data = "";
   for await (const chunk of stdin) data += chunk;
   return data.trim();
 }
@@ -79,7 +75,7 @@ async function readFromStdin() {
 async function promptKey() {
   const rl = readline.createInterface({ input: stdin, output: stdout });
   try {
-    const answer = await rl.question('Paste your OpenRouter API key (sk-or-...): ');
+    const answer = await rl.question("Paste your OpenRouter API key (sk-or-...): ");
     return answer.trim();
   } finally {
     rl.close();
@@ -104,7 +100,7 @@ async function promptManagementKey() {
   const rl = readline.createInterface({ input: stdin, output: stdout });
   try {
     const answer = await rl.question(
-      `Paste your OpenRouter management key (sk-or-v1-...). Create one at\n  ${PROVISIONING_KEYS_URL}\n› `
+      `Paste your OpenRouter management key (sk-or-v1-...). Create one at\n  ${PROVISIONING_KEYS_URL}\n› `,
     );
     return answer.trim();
   } finally {
@@ -114,136 +110,136 @@ async function promptManagementKey() {
 
 async function pkceFlow({ port, openInBrowser, authUrl, baseUrl }) {
   const verifier = base64url(crypto.randomBytes(48));
-  const challenge = base64url(
-    crypto.createHash('sha256').update(verifier).digest()
-  );
+  const challenge = base64url(crypto.createHash("sha256").update(verifier).digest());
 
   const codePromise = new Promise((resolve, reject) => {
     const server = http.createServer((req, res) => {
       const u = new URL(req.url, `http://localhost`);
-      if (u.pathname !== '/callback') {
-        res.writeHead(404).end('not found');
+      if (u.pathname !== "/callback") {
+        res.writeHead(404).end("not found");
         return;
       }
-      const code = u.searchParams.get('code');
-      const error = u.searchParams.get('error');
+      const code = u.searchParams.get("code");
+      const error = u.searchParams.get("error");
       const html = (title, body) =>
         `<!doctype html><html><head><meta charset="utf-8"><title>${title}</title>` +
         `<style>body{font-family:-apple-system,system-ui,sans-serif;max-width:480px;margin:6rem auto;padding:0 1rem;color:#222}h1{font-weight:600}` +
         `code{background:#f4f4f5;padding:.1rem .35rem;border-radius:.25rem}</style></head><body>${body}</body></html>`;
       if (error) {
-        res.writeHead(400, { 'Content-Type': 'text/html' }).end(
-          html('Login failed', `<h1>Login failed</h1><p>${error}</p>`)
-        );
+        res
+          .writeHead(400, { "Content-Type": "text/html" })
+          .end(html("Login failed", `<h1>Login failed</h1><p>${error}</p>`));
         server.close();
         reject(new Error(`OAuth error: ${error}`));
         return;
       }
       if (!code) {
-        res.writeHead(400, { 'Content-Type': 'text/html' }).end(
-          html('Missing code', '<h1>Missing code</h1>')
-        );
+        res
+          .writeHead(400, { "Content-Type": "text/html" })
+          .end(html("Missing code", "<h1>Missing code</h1>"));
         return;
       }
-      res.writeHead(200, { 'Content-Type': 'text/html' }).end(
-        html(
-          'OpenRouter CLI: signed in',
-          '<h1>You are signed in.</h1><p>You can close this tab and return to the terminal.</p>'
-        )
-      );
+      res
+        .writeHead(200, { "Content-Type": "text/html" })
+        .end(
+          html(
+            "OpenRouter CLI: signed in",
+            "<h1>You are signed in.</h1><p>You can close this tab and return to the terminal.</p>",
+          ),
+        );
       setTimeout(() => server.close(), 100);
       resolve(code);
     });
-    server.on('error', reject);
-    server.listen(port || 0, '127.0.0.1', () => {
+    server.on("error", reject);
+    server.listen(port || 0, "127.0.0.1", () => {
       const actualPort = server.address().port;
       const callback = `http://localhost:${actualPort}/callback`;
       const params = new URLSearchParams({
         callback_url: callback,
         code_challenge: challenge,
-        code_challenge_method: 'S256'
+        code_challenge_method: "S256",
       });
       const url = `${authUrl}?${params.toString()}`;
       info(`Listening on ${callback}`);
       if (openInBrowser) {
-        info('Opening browser...');
+        info("Opening browser...");
         openBrowser(url);
       }
-      outln(c.bold('Open this URL to sign in:'));
-      outln('  ' + c.cyan(url));
-      outln('');
-      info('Waiting for callback (press Ctrl+C to cancel)...');
+      outln(c.bold("Open this URL to sign in:"));
+      outln("  " + c.cyan(url));
+      outln("");
+      info("Waiting for callback (press Ctrl+C to cancel)...");
     });
   });
 
   const code = await codePromise;
-  info('Exchanging authorization code for API key...');
-  const data = await api('POST', '/auth/keys', {
+  info("Exchanging authorization code for API key...");
+  const data = await api("POST", "/auth/keys", {
     requireAuth: false,
     auth: { baseUrl },
     body: {
       code,
       code_verifier: verifier,
-      code_challenge_method: 'S256'
-    }
+      code_challenge_method: "S256",
+    },
   });
   return data;
 }
 
 export async function loginCommand(argv) {
   const { values } = parseArgs(argv, {
-    'no-browser': { type: 'boolean' },
-    port: { type: 'string' },
-    'auth-url': { type: 'string' },
-    stdin: { type: 'boolean' },
-    management: { type: 'boolean' }
+    "no-browser": { type: "boolean" },
+    port: { type: "string" },
+    "auth-url": { type: "string" },
+    stdin: { type: "boolean" },
+    management: { type: "boolean" },
   });
   if (values.help) {
     process.stdout.write(HELP);
     return 0;
   }
 
-  const baseUrl = values['base-url'] || DEFAULT_BASE_URL;
-  const authUrl = values['auth-url'] || DEFAULT_AUTH_URL;
+  const baseUrl = values["base-url"] || DEFAULT_BASE_URL;
+  const authUrl = values["auth-url"] || DEFAULT_AUTH_URL;
 
   // Management-key path: never OAuth, always paste/stdin/--key.
   if (values.management) {
     let key = values.key;
     if (!key && values.stdin) key = await readFromStdin();
     if (!key) key = await promptManagementKey();
-    if (!key || !key.startsWith('sk-or-')) {
+    if (!key || !key.startsWith("sk-or-")) {
       throw new Error('Expected management key starting with "sk-or-".');
     }
     await saveManagementKey(key, {
-      baseUrl: values['base-url'] || undefined
+      baseUrl: values["base-url"] || undefined,
     });
-    if (isJsonMode()) printJSON({ saved: true, slot: 'management' });
+    if (isJsonMode()) printJSON({ saved: true, slot: "management" });
     else info(`Saved management key (${key.slice(0, 12)}...).`);
     return 0;
   }
 
   if (values.key || values.stdin) {
     const key = values.key || (await readFromStdin());
-    if (!key || !key.startsWith('sk-or-')) {
+    if (!key || !key.startsWith("sk-or-")) {
       throw new Error('Expected API key starting with "sk-or-".');
     }
     await saveKey(key, {
-      baseUrl: values['base-url'] || undefined
+      baseUrl: values["base-url"] || undefined,
     });
     info(`Saved API key (${key.slice(0, 12)}...).`);
-    if (isJsonMode()) printJSON({ saved: true, slot: 'user' });
+    if (isJsonMode()) printJSON({ saved: true, slot: "user" });
     return 0;
   }
 
   // Interactive: OAuth PKCE, falling back to manual paste only if it fails.
-  const port = numberOption(values.port, '--port') ?? 0;
+  const port = numberOption(values.port, "--port") ?? 0;
   let result;
   try {
     result = await pkceFlow({
       port,
-      openInBrowser: !values['no-browser'],
+      openInBrowser: !values["no-browser"],
       authUrl,
-      baseUrl
+      baseUrl,
     });
   } catch (err) {
     if (process.env.OPENROUTER_DEBUG) info(String(err.stack || err));
@@ -251,38 +247,38 @@ export async function loginCommand(argv) {
     // answer one.
     if (isJsonMode() || !stdin.isTTY) throw err;
     process.stderr.write(`OAuth flow failed: ${err.message}\n`);
-    info('Falling back to manual key entry.');
+    info("Falling back to manual key entry.");
     const key = await promptKey();
-    if (!key) throw new Error('No API key provided.');
+    if (!key) throw new Error("No API key provided.");
     await saveKey(key);
-    if (isJsonMode()) printJSON({ saved: true, mode: 'manual' });
-    else info('Saved API key.');
+    if (isJsonMode()) printJSON({ saved: true, mode: "manual" });
+    else info("Saved API key.");
     return 0;
   }
 
   await saveKey(result.key, {
     userId: result.user_id,
-    baseUrl: values['base-url'] || undefined
+    baseUrl: values["base-url"] || undefined,
   });
   if (isJsonMode()) {
     printJSON({ saved: true, user_id: result.user_id });
   } else {
-    outln(c.green('Signed in.') + ' ' + c.dim(`user_id=${result.user_id}`));
+    outln(c.green("Signed in.") + " " + c.dim(`user_id=${result.user_id}`));
   }
   return 0;
 }
 
 export async function logoutCommand(argv) {
   const { values } = parseArgs(argv, {
-    management: { type: 'boolean' },
-    all: { type: 'boolean' }
+    management: { type: "boolean" },
+    all: { type: "boolean" },
   });
   if (values.help) {
     process.stdout.write(
-      'Usage: openrouter logout [--management|--all]\n\n' +
-        'Remove the locally stored API key. By default removes the user key.\n' +
-        '  --management  Remove the management key only\n' +
-        '  --all         Remove both\n'
+      "Usage: openrouter logout [--management|--all]\n\n" +
+        "Remove the locally stored API key. By default removes the user key.\n" +
+        "  --management  Remove the management key only\n" +
+        "  --all         Remove both\n",
     );
     return 0;
   }
@@ -292,21 +288,21 @@ export async function logoutCommand(argv) {
     if (cfg.apiKey) {
       delete cfg.apiKey;
       delete cfg.userId;
-      removed.push('user');
+      removed.push("user");
     }
   }
   if (values.all || values.management) {
     if (cfg.managementKey) {
       delete cfg.managementKey;
-      removed.push('management');
+      removed.push("management");
     }
   }
   if (!removed.length) {
-    info('No matching key was stored.');
+    info("No matching key was stored.");
     return 0;
   }
   await saveConfig(cfg);
   if (isJsonMode()) printJSON({ logged_out: removed });
-  else info(`Logged out (${removed.join(', ')}).`);
+  else info(`Logged out (${removed.join(", ")}).`);
   return 0;
 }

--- a/src/commands/messages.js
+++ b/src/commands/messages.js
@@ -3,10 +3,10 @@ import {
   authFromValues,
   numberOption,
   readStdinIfPiped,
-  shouldStream
-} from '../args.js';
-import { api, assertNoStreamError, sseStream } from '../api.js';
-import { isJsonMode, out, outln, printJSON } from '../output.js';
+  shouldStream,
+} from "../args.js";
+import { api, assertNoStreamError, sseStream } from "../api.js";
+import { isJsonMode, out, outln, printJSON } from "../output.js";
 
 const HELP = `Usage: openrouter messages [prompt...] [options]
 
@@ -42,11 +42,11 @@ Options:
 `;
 
 async function resolvePrompt(values, positionals) {
-  if (!values.model) throw new Error('--model is required');
-  let prompt = positionals.join(' ').trim();
+  if (!values.model) throw new Error("--model is required");
+  let prompt = positionals.join(" ").trim();
   const piped = await readStdinIfPiped();
   if (piped) prompt = prompt ? `${prompt}\n\n${piped}` : piped;
-  if (!prompt) throw new Error('No prompt.');
+  if (!prompt) throw new Error("No prompt.");
   return prompt;
 }
 
@@ -59,23 +59,23 @@ function applyNumeric(body, values, map) {
 
 async function loadBody(value) {
   if (!value) return null;
-  if (value.startsWith('@')) {
-    const { readFile } = await import('node:fs/promises');
-    return JSON.parse(await readFile(value.slice(1), 'utf8'));
+  if (value.startsWith("@")) {
+    const { readFile } = await import("node:fs/promises");
+    return JSON.parse(await readFile(value.slice(1), "utf8"));
   }
   return JSON.parse(value);
 }
 
 export async function messagesCommand(argv) {
   const { values, positionals } = parseArgs(argv, {
-    model: { type: 'string', short: 'm' },
-    system: { type: 'string', short: 's' },
-    'max-tokens': { type: 'string' },
-    temperature: { type: 'string' },
-    stream: { type: 'boolean' },
-    'no-stream': { type: 'boolean' },
-    raw: { type: 'boolean' },
-    body: { type: 'string' }
+    model: { type: "string", short: "m" },
+    system: { type: "string", short: "s" },
+    "max-tokens": { type: "string" },
+    temperature: { type: "string" },
+    stream: { type: "boolean" },
+    "no-stream": { type: "boolean" },
+    raw: { type: "boolean" },
+    body: { type: "string" },
   });
   if (values.help) {
     process.stdout.write(HELP);
@@ -87,58 +87,58 @@ export async function messagesCommand(argv) {
     const prompt = await resolvePrompt(values, positionals);
     body = {
       model: values.model,
-      max_tokens: numberOption(values['max-tokens'], '--max-tokens') ?? 1024,
-      messages: [{ role: 'user', content: prompt }]
+      max_tokens: numberOption(values["max-tokens"], "--max-tokens") ?? 1024,
+      messages: [{ role: "user", content: prompt }],
     };
     if (values.system) body.system = values.system;
-    applyNumeric(body, values, { temperature: 'temperature' });
+    applyNumeric(body, values, { temperature: "temperature" });
   }
 
   if (shouldStream(values)) {
     body.stream = true;
-    const res = await api('POST', '/messages', {
+    const res = await api("POST", "/messages", {
       auth: authFromValues(values),
       body,
       raw: true,
-      headers: { Accept: 'text/event-stream' }
+      headers: { Accept: "text/event-stream" },
     });
     for await (const evt of sseStream(res)) {
       assertNoStreamError(evt);
       const t = evt.type;
-      if (t === 'content_block_delta' && evt.delta && evt.delta.text) {
+      if (t === "content_block_delta" && evt.delta && evt.delta.text) {
         out(evt.delta.text);
       }
     }
-    if (process.stdout.isTTY) out('\n');
+    if (process.stdout.isTTY) out("\n");
     return 0;
   }
 
-  const data = await api('POST', '/messages', {
+  const data = await api("POST", "/messages", {
     auth: authFromValues(values),
-    body
+    body,
   });
   if (isJsonMode() || values.raw) {
     printJSON(data);
   } else {
     const blocks = data.content || [];
-    for (const b of blocks) if (b.type === 'text') outln(b.text);
+    for (const b of blocks) if (b.type === "text") outln(b.text);
   }
   return 0;
 }
 
 export async function responsesCommand(argv) {
   const { values, positionals } = parseArgs(argv, {
-    model: { type: 'string', short: 'm' },
-    instructions: { type: 'string', short: 's' },
-    'max-tokens': { type: 'string' },
-    temperature: { type: 'string' },
-    'top-p': { type: 'string' },
-    seed: { type: 'string' },
-    reasoning: { type: 'string' },
-    stream: { type: 'boolean' },
-    'no-stream': { type: 'boolean' },
-    raw: { type: 'boolean' },
-    body: { type: 'string' }
+    model: { type: "string", short: "m" },
+    instructions: { type: "string", short: "s" },
+    "max-tokens": { type: "string" },
+    temperature: { type: "string" },
+    "top-p": { type: "string" },
+    seed: { type: "string" },
+    reasoning: { type: "string" },
+    stream: { type: "boolean" },
+    "no-stream": { type: "boolean" },
+    raw: { type: "boolean" },
+    body: { type: "string" },
   });
   if (values.help) {
     process.stdout.write(HELP_RESPONSES);
@@ -151,44 +151,47 @@ export async function responsesCommand(argv) {
     body = { model: values.model, input: prompt };
     if (values.instructions) body.instructions = values.instructions;
     applyNumeric(body, values, {
-      'max-tokens': 'max_output_tokens',
-      temperature: 'temperature',
-      'top-p': 'top_p',
-      seed: 'seed'
+      "max-tokens": "max_output_tokens",
+      temperature: "temperature",
+      "top-p": "top_p",
+      seed: "seed",
     });
     if (values.reasoning) body.reasoning = { effort: values.reasoning };
   }
 
   if (shouldStream(values)) {
     body.stream = true;
-    const res = await api('POST', '/responses', {
+    const res = await api("POST", "/responses", {
       auth: authFromValues(values),
       body,
       raw: true,
-      headers: { Accept: 'text/event-stream' }
+      headers: { Accept: "text/event-stream" },
     });
     for await (const evt of sseStream(res)) {
       assertNoStreamError(evt);
-      if (evt.type && evt.type.endsWith('output_text.delta') && evt.delta) {
+      if (evt.type && evt.type.endsWith("output_text.delta") && evt.delta) {
         out(evt.delta);
       }
     }
-    if (process.stdout.isTTY) out('\n');
+    if (process.stdout.isTTY) out("\n");
     return 0;
   }
 
-  const data = await api('POST', '/responses', {
+  const data = await api("POST", "/responses", {
     auth: authFromValues(values),
-    body
+    body,
   });
   if (isJsonMode() || values.raw) {
     printJSON(data);
   } else {
     const text =
       data.output_text ||
-      (data.output && data.output.flatMap?.((o) =>
-        (o.content || []).filter((c) => c.type === 'output_text').map((c) => c.text)
-      ).join('\n'));
+      (data.output &&
+        data.output
+          .flatMap?.((o) =>
+            (o.content || []).filter((c) => c.type === "output_text").map((c) => c.text),
+          )
+          .join("\n"));
     outln(text || JSON.stringify(data));
   }
   return 0;

--- a/src/commands/misc.js
+++ b/src/commands/misc.js
@@ -3,32 +3,32 @@ import {
   authFromValues,
   numberOption,
   PAGINATION_OPTIONS,
-  paginationQuery
-} from '../args.js';
-import { api } from '../api.js';
-import { printResult, table } from '../output.js';
+  paginationQuery,
+} from "../args.js";
+import { api } from "../api.js";
+import { printResult, table } from "../output.js";
 
 async function orgMembersCommand(argv) {
   const { values } = parseArgs(argv, PAGINATION_OPTIONS);
   if (values.help) {
     process.stdout.write(
-      'Usage: openrouter org members [--offset N] [--limit N]\n\nList organization members. Requires a management key.\n'
+      "Usage: openrouter org members [--offset N] [--limit N]\n\nList organization members. Requires a management key.\n",
     );
     return 0;
   }
   const query = paginationQuery(values);
-  const data = await api('GET', '/organization/members', {
+  const data = await api("GET", "/organization/members", {
     auth: authFromValues(values),
     requiresManagement: true,
-    query
+    query,
   });
   printResult(data, () => {
     const rows = data.data || [];
     table(rows, [
-      { label: 'user_id', value: (m) => m.user_id || m.id || '' },
-      { label: 'email', value: (m) => m.email || '' },
-      { label: 'role', value: (m) => m.role || '' },
-      { label: 'name', value: (m) => m.name || '' }
+      { label: "user_id", value: (m) => m.user_id || m.id || "" },
+      { label: "email", value: (m) => m.email || "" },
+      { label: "role", value: (m) => m.role || "" },
+      { label: "name", value: (m) => m.name || "" },
     ]);
   });
   return 0;
@@ -37,10 +37,10 @@ async function orgMembersCommand(argv) {
 export async function orgCommand(argv) {
   const sub = argv[0];
   const rest = argv.slice(1);
-  if (sub === 'members') return orgMembersCommand(rest);
-  if (!sub || sub === '-h' || sub === '--help' || sub === 'help') {
+  if (sub === "members") return orgMembersCommand(rest);
+  if (!sub || sub === "-h" || sub === "--help" || sub === "help") {
     process.stdout.write(
-      'Usage: openrouter org <subcommand>\n\nSubcommands:\n  members   List organization members (management key)\n'
+      "Usage: openrouter org <subcommand>\n\nSubcommands:\n  members   List organization members (management key)\n",
     );
     return sub ? 0 : 1;
   }
@@ -51,12 +51,12 @@ export async function zdrCommand(argv) {
   const { values } = parseArgs(argv, {});
   if (values.help) {
     process.stdout.write(
-      'Usage: openrouter zdr\n\nPreview the impact of Zero Data Retention on the available endpoints.\n'
+      "Usage: openrouter zdr\n\nPreview the impact of Zero Data Retention on the available endpoints.\n",
     );
     return 0;
   }
-  const data = await api('GET', '/endpoints/zdr', {
-    auth: authFromValues(values)
+  const data = await api("GET", "/endpoints/zdr", {
+    auth: authFromValues(values),
   });
   printResult(data);
   return 0;
@@ -64,41 +64,41 @@ export async function zdrCommand(argv) {
 
 export async function authCodeCommand(argv) {
   const { values } = parseArgs(argv, {
-    'callback-url': { type: 'string' },
-    'code-challenge': { type: 'string' },
-    'code-challenge-method': { type: 'string' },
-    'expires-at': { type: 'string' },
-    'key-label': { type: 'string' },
-    limit: { type: 'string' },
-    'usage-limit-type': { type: 'string' }
+    "callback-url": { type: "string" },
+    "code-challenge": { type: "string" },
+    "code-challenge-method": { type: "string" },
+    "expires-at": { type: "string" },
+    "key-label": { type: "string" },
+    limit: { type: "string" },
+    "usage-limit-type": { type: "string" },
   });
-  if (values.help || !values['callback-url']) {
+  if (values.help || !values["callback-url"]) {
     process.stdout.write(
-      'Usage: openrouter auth-code --callback-url <url> [options]\n\n' +
-        'Mint a PKCE authorization code so a user can claim a key for your app.\n' +
-        'Requires a management key.\n\n' +
-        'Options:\n' +
-        '  --callback-url <url>           HTTPS URL on port 443 or 3000 (required)\n' +
-        '  --code-challenge <s>           PKCE challenge\n' +
-        '  --code-challenge-method <m>    S256 | plain\n' +
-        '  --expires-at <iso>             Optional ISO 8601 UTC expiry\n' +
-        '  --key-label <text>             Custom label for the resulting key\n' +
-        '  --limit <usd>                  Credit limit\n' +
-        '  --usage-limit-type <p>         daily | weekly | monthly\n'
+      "Usage: openrouter auth-code --callback-url <url> [options]\n\n" +
+        "Mint a PKCE authorization code so a user can claim a key for your app.\n" +
+        "Requires a management key.\n\n" +
+        "Options:\n" +
+        "  --callback-url <url>           HTTPS URL on port 443 or 3000 (required)\n" +
+        "  --code-challenge <s>           PKCE challenge\n" +
+        "  --code-challenge-method <m>    S256 | plain\n" +
+        "  --expires-at <iso>             Optional ISO 8601 UTC expiry\n" +
+        "  --key-label <text>             Custom label for the resulting key\n" +
+        "  --limit <usd>                  Credit limit\n" +
+        "  --usage-limit-type <p>         daily | weekly | monthly\n",
     );
     return values.help ? 0 : 1;
   }
-  const body = { callback_url: values['callback-url'] };
-  if (values['code-challenge']) body.code_challenge = values['code-challenge'];
-  if (values['code-challenge-method']) body.code_challenge_method = values['code-challenge-method'];
-  if (values['expires-at']) body.expires_at = values['expires-at'];
-  if (values['key-label']) body.key_label = values['key-label'];
-  if (values.limit) body.limit = numberOption(values.limit, '--limit');
-  if (values['usage-limit-type']) body.usage_limit_type = values['usage-limit-type'];
-  const data = await api('POST', '/auth/keys/code', {
+  const body = { callback_url: values["callback-url"] };
+  if (values["code-challenge"]) body.code_challenge = values["code-challenge"];
+  if (values["code-challenge-method"]) body.code_challenge_method = values["code-challenge-method"];
+  if (values["expires-at"]) body.expires_at = values["expires-at"];
+  if (values["key-label"]) body.key_label = values["key-label"];
+  if (values.limit) body.limit = numberOption(values.limit, "--limit");
+  if (values["usage-limit-type"]) body.usage_limit_type = values["usage-limit-type"];
+  const data = await api("POST", "/auth/keys/code", {
     auth: authFromValues(values),
     requiresManagement: true,
-    body
+    body,
   });
   printResult(data);
   return 0;

--- a/src/commands/models.js
+++ b/src/commands/models.js
@@ -1,16 +1,16 @@
-import { parseArgs, authFromValues } from '../args.js';
-import { api } from '../api.js';
-import { c, isJsonMode, outln, pricePerMillion, printResult, table } from '../output.js';
+import { parseArgs, authFromValues } from "../args.js";
+import { api } from "../api.js";
+import { c, isJsonMode, outln, pricePerMillion, printResult, table } from "../output.js";
 
-const ENDPOINT_SORT_FIELDS = ['throughput', 'latency', 'prompt', 'completion', 'uptime', 'context'];
-const MODEL_SORT_FIELDS = ['id', 'name', 'context', 'prompt', 'completion'];
+const ENDPOINT_SORT_FIELDS = ["throughput", "latency", "prompt", "completion", "uptime", "context"];
+const MODEL_SORT_FIELDS = ["id", "name", "context", "prompt", "completion"];
 
 const PRICE_COLUMN = {
-  label: 'in/out $/M',
+  label: "in/out $/M",
   value: (x) => {
     const p = x.pricing || {};
     return `${pricePerMillion(p.prompt)}/${pricePerMillion(p.completion)}`;
-  }
+  },
 };
 
 const HELP = `Usage: openrouter models [subcommand] [options]
@@ -36,29 +36,30 @@ Options for list:
 function listFormatter(data) {
   const rows = data.data || [];
   table(rows.slice(0, 200), [
-    { label: 'id', value: (m) => m.id },
+    { label: "id", value: (m) => m.id },
     {
-      label: 'context',
-      value: (m) => (m.context_length || '').toLocaleString?.() ?? m.context_length
+      label: "context",
+      value: (m) => (m.context_length || "").toLocaleString?.() ?? m.context_length,
     },
     PRICE_COLUMN,
-    { label: 'name', value: (m) => m.name || '' }
+    { label: "name", value: (m) => m.name || "" },
   ]);
-  if (rows.length > 200) outln(c.dim(`... ${rows.length - 200} more (use --json for the full list)`));
+  if (rows.length > 200)
+    outln(c.dim(`... ${rows.length - 200} more (use --json for the full list)`));
 }
 
 function fmtPerMillion(x) {
-  if (x == null || x === '') return '-';
+  if (x == null || x === "") return "-";
   const n = Number(x);
   if (!Number.isFinite(n)) return String(x);
-  return '$' + (n * 1e6).toFixed(n * 1e6 < 0.1 ? 4 : 2) + '/M';
+  return "$" + (n * 1e6).toFixed(n * 1e6 < 0.1 ? 4 : 2) + "/M";
 }
 
 function fmtFlat(x) {
-  if (x == null || x === '') return '-';
+  if (x == null || x === "") return "-";
   const n = Number(x);
   if (!Number.isFinite(n)) return String(x);
-  return '$' + n.toFixed(n < 0.001 ? 6 : 4);
+  return "$" + n.toFixed(n < 0.001 ? 6 : 4);
 }
 
 function renderModelDetail(m) {
@@ -66,92 +67,93 @@ function renderModelDetail(m) {
   outln(c.dim(m.id));
   if (m.canonical_slug && m.canonical_slug !== m.id) outln(c.dim(`canonical: ${m.canonical_slug}`));
   if (m.hugging_face_id) outln(c.dim(`hugging_face: ${m.hugging_face_id}`));
-  outln('');
+  outln("");
   if (m.description) {
     outln(m.description);
-    outln('');
+    outln("");
   }
 
   const a = m.architecture || {};
-  outln(c.bold('architecture'));
-  outln(`  modality:          ${a.modality ?? '-'}`);
-  outln(`  input_modalities:  ${(a.input_modalities || []).join(', ') || '-'}`);
-  outln(`  output_modalities: ${(a.output_modalities || []).join(', ') || '-'}`);
-  outln(`  tokenizer:         ${a.tokenizer ?? '-'}`);
-  outln(`  instruct_type:     ${a.instruct_type ?? '-'}`);
-  outln('');
+  outln(c.bold("architecture"));
+  outln(`  modality:          ${a.modality ?? "-"}`);
+  outln(`  input_modalities:  ${(a.input_modalities || []).join(", ") || "-"}`);
+  outln(`  output_modalities: ${(a.output_modalities || []).join(", ") || "-"}`);
+  outln(`  tokenizer:         ${a.tokenizer ?? "-"}`);
+  outln(`  instruct_type:     ${a.instruct_type ?? "-"}`);
+  outln("");
 
   const tp = m.top_provider || {};
-  outln(c.bold('top provider'));
-  outln(`  context_length:        ${tp.context_length ?? m.context_length ?? '-'}`);
-  outln(`  max_completion_tokens: ${tp.max_completion_tokens ?? '-'}`);
-  outln(`  is_moderated:          ${tp.is_moderated ?? '-'}`);
-  outln('');
+  outln(c.bold("top provider"));
+  outln(`  context_length:        ${tp.context_length ?? m.context_length ?? "-"}`);
+  outln(`  max_completion_tokens: ${tp.max_completion_tokens ?? "-"}`);
+  outln(`  is_moderated:          ${tp.is_moderated ?? "-"}`);
+  outln("");
 
   const p = m.pricing || {};
-  outln(c.bold('pricing  ') + c.dim('(per token unless noted)'));
+  outln(c.bold("pricing  ") + c.dim("(per token unless noted)"));
   const priceRows = [
-    ['prompt (input)', fmtPerMillion(p.prompt)],
-    ['completion (output)', fmtPerMillion(p.completion)],
-    ['input cache read', fmtPerMillion(p.input_cache_read)],
-    ['input cache write', fmtPerMillion(p.input_cache_write)],
-    ['internal reasoning', fmtPerMillion(p.internal_reasoning)],
-    ['image input', p.image != null ? fmtFlat(p.image) + ' /image' : '-'],
-    ['request', p.request != null ? fmtFlat(p.request) + ' /request' : '-'],
-    ['web search', p.web_search != null ? fmtFlat(p.web_search) + ' /search' : '-']
+    ["prompt (input)", fmtPerMillion(p.prompt)],
+    ["completion (output)", fmtPerMillion(p.completion)],
+    ["input cache read", fmtPerMillion(p.input_cache_read)],
+    ["input cache write", fmtPerMillion(p.input_cache_write)],
+    ["internal reasoning", fmtPerMillion(p.internal_reasoning)],
+    ["image input", p.image != null ? fmtFlat(p.image) + " /image" : "-"],
+    ["request", p.request != null ? fmtFlat(p.request) + " /request" : "-"],
+    ["web search", p.web_search != null ? fmtFlat(p.web_search) + " /search" : "-"],
   ];
   for (const [k, v] of priceRows) {
-    if (v === '-') continue;
+    if (v === "-") continue;
     outln(`  ${k.padEnd(22)} ${v}`);
   }
-  outln('');
+  outln("");
 
-  outln(c.bold('supported_parameters'));
-  outln('  ' + ((m.supported_parameters || []).join(', ') || '-'));
-  outln('');
+  outln(c.bold("supported_parameters"));
+  outln("  " + ((m.supported_parameters || []).join(", ") || "-"));
+  outln("");
 
   if (m.default_parameters && Object.keys(m.default_parameters).length) {
-    outln(c.bold('default_parameters'));
+    outln(c.bold("default_parameters"));
     for (const [k, v] of Object.entries(m.default_parameters)) {
       if (v == null) continue;
       outln(`  ${k}: ${v}`);
     }
-    outln('');
+    outln("");
   }
 
   if (m.knowledge_cutoff) outln(c.dim(`knowledge_cutoff: ${m.knowledge_cutoff}`));
   if (m.expiration_date) outln(c.dim(`expiration_date: ${m.expiration_date}`));
   if (m.created) outln(c.dim(`created: ${new Date(m.created * 1000).toISOString()}`));
-  if (m.per_request_limits) outln(c.dim(`per_request_limits: ${JSON.stringify(m.per_request_limits)}`));
+  if (m.per_request_limits)
+    outln(c.dim(`per_request_limits: ${JSON.stringify(m.per_request_limits)}`));
 }
 
 export async function modelsCommand(argv) {
   // A leading non-flag token is the subcommand; otherwise default to list
   // and keep argv intact so the list branch still sees its flags.
-  const sub = argv[0] && !argv[0].startsWith('-') ? argv[0] : 'list';
+  const sub = argv[0] && !argv[0].startsWith("-") ? argv[0] : "list";
   const rest = sub === argv[0] ? argv.slice(1) : argv;
 
-  if (sub === 'show' || sub === 'info' || sub === 'detail') {
+  if (sub === "show" || sub === "info" || sub === "detail") {
     const { values, positionals } = parseArgs(rest, {});
     if (values.help || positionals.length === 0) {
       process.stdout.write(
-        'Usage: openrouter models show <model-id>\n\nShow full details (pricing, architecture, capabilities) for one model.\n'
+        "Usage: openrouter models show <model-id>\n\nShow full details (pricing, architecture, capabilities) for one model.\n",
       );
       return values.help ? 0 : 1;
     }
     const target = positionals[0].toLowerCase();
-    const data = await api('GET', '/models', {
+    const data = await api("GET", "/models", {
       auth: authFromValues(values),
-      requireAuth: false
+      requireAuth: false,
     });
     const rows = data.data || [];
-    let m = rows.find((r) => (r.id || '').toLowerCase() === target);
-    if (!m) m = rows.find((r) => (r.canonical_slug || '').toLowerCase() === target);
+    let m = rows.find((r) => (r.id || "").toLowerCase() === target);
+    if (!m) m = rows.find((r) => (r.canonical_slug || "").toLowerCase() === target);
     if (!m) {
       const matches = rows.filter(
         (r) =>
-          (r.id || '').toLowerCase().includes(target) ||
-          (r.name || '').toLowerCase().includes(target)
+          (r.id || "").toLowerCase().includes(target) ||
+          (r.name || "").toLowerCase().includes(target),
       );
       if (matches.length === 1) m = matches[0];
       else if (matches.length > 1) {
@@ -159,7 +161,7 @@ export async function modelsCommand(argv) {
           `Multiple matches for "${positionals[0]}":\n  ${matches
             .slice(0, 10)
             .map((r) => r.id)
-            .join('\n  ')}${matches.length > 10 ? `\n  ...and ${matches.length - 10} more` : ''}`
+            .join("\n  ")}${matches.length > 10 ? `\n  ...and ${matches.length - 10} more` : ""}`,
         );
       }
     }
@@ -173,36 +175,36 @@ export async function modelsCommand(argv) {
     return 0;
   }
 
-  if (sub === 'endpoints') {
+  if (sub === "endpoints") {
     const { values, positionals } = parseArgs(rest, {
-      sort: { type: 'string' },
-      best: { type: 'boolean' }
+      sort: { type: "string" },
+      best: { type: "boolean" },
     });
     if (values.help || positionals.length === 0) {
       process.stdout.write(
-        'Usage: openrouter models endpoints <author>/<slug> [options]\n\n' +
-          'List provider endpoints (variants) for a model, with throughput,\n' +
-          'latency, uptime, and pricing.\n\n' +
-          'Options:\n' +
-          '  --sort <field>   throughput | latency | prompt | completion | uptime | context\n' +
-          '                   Sort the list before display (best first).\n' +
-          '  --best           Show only the top row after sorting.\n'
+        "Usage: openrouter models endpoints <author>/<slug> [options]\n\n" +
+          "List provider endpoints (variants) for a model, with throughput,\n" +
+          "latency, uptime, and pricing.\n\n" +
+          "Options:\n" +
+          "  --sort <field>   throughput | latency | prompt | completion | uptime | context\n" +
+          "                   Sort the list before display (best first).\n" +
+          "  --best           Show only the top row after sorting.\n",
       );
       return values.help ? 0 : 1;
     }
     if (values.sort && !ENDPOINT_SORT_FIELDS.includes(values.sort)) {
       throw new Error(
-        `Unknown --sort field "${values.sort}". Expected: ${ENDPOINT_SORT_FIELDS.join(' | ')}`
+        `Unknown --sort field "${values.sort}". Expected: ${ENDPOINT_SORT_FIELDS.join(" | ")}`,
       );
     }
     const target = positionals[0];
-    const slash = target.indexOf('/');
-    if (slash === -1) throw new Error('Expected <author>/<slug>');
+    const slash = target.indexOf("/");
+    if (slash === -1) throw new Error("Expected <author>/<slug>");
     const author = target.slice(0, slash);
     const slug = target.slice(slash + 1);
-    const data = await api('GET', `/models/${author}/${slug}/endpoints`, {
+    const data = await api("GET", `/models/${author}/${slug}/endpoints`, {
       auth: authFromValues(values),
-      requireAuth: false
+      requireAuth: false,
     });
     let eps = (data.data && data.data.endpoints) || data.endpoints || [];
     if (values.sort) {
@@ -212,16 +214,23 @@ export async function modelsCommand(argv) {
         const t = e.throughput_last_30m || {};
         const l = e.latency_last_30m || {};
         switch (key) {
-          case 'throughput': return -(t.p50 ?? -Infinity);
-          case 'latency': return l.p50 ?? Infinity;
-          case 'prompt': return Number(p.prompt ?? Infinity);
-          case 'completion': return Number(p.completion ?? Infinity);
-          case 'uptime': return -(e.uptime_last_30m ?? -Infinity);
-          case 'context': return -(e.context_length ?? -Infinity);
+          case "throughput":
+            return -(t.p50 ?? -Infinity);
+          case "latency":
+            return l.p50 ?? Infinity;
+          case "prompt":
+            return Number(p.prompt ?? Infinity);
+          case "completion":
+            return Number(p.completion ?? Infinity);
+          case "uptime":
+            return -(e.uptime_last_30m ?? -Infinity);
+          case "context":
+            return -(e.context_length ?? -Infinity);
         }
       };
       eps = [...eps].sort((a, b) => {
-        const va = score(a), vb = score(b);
+        const va = score(a),
+          vb = score(b);
         if (Number.isNaN(va)) return 1;
         if (Number.isNaN(vb)) return -1;
         return va - vb;
@@ -231,72 +240,72 @@ export async function modelsCommand(argv) {
 
     printResult({ ...data, data: { ...(data.data || {}), endpoints: eps } }, () => {
       table(eps, [
-        { label: 'provider', value: (e) => e.provider_name || e.name || '' },
-        { label: 'context', value: (e) => e.context_length ?? '' },
-        { label: 'max_out', value: (e) => e.max_completion_tokens ?? '' },
+        { label: "provider", value: (e) => e.provider_name || e.name || "" },
+        { label: "context", value: (e) => e.context_length ?? "" },
+        { label: "max_out", value: (e) => e.max_completion_tokens ?? "" },
         PRICE_COLUMN,
         {
-          label: 'tput p50',
+          label: "tput p50",
           value: (e) =>
             e.throughput_last_30m?.p50 != null
-              ? Number(e.throughput_last_30m.p50).toFixed(0) + ' tok/s'
-              : ''
+              ? Number(e.throughput_last_30m.p50).toFixed(0) + " tok/s"
+              : "",
         },
         {
-          label: 'lat p50',
+          label: "lat p50",
           value: (e) =>
             e.latency_last_30m?.p50 != null
-              ? Number(e.latency_last_30m.p50).toFixed(0) + ' ms'
-              : ''
+              ? Number(e.latency_last_30m.p50).toFixed(0) + " ms"
+              : "",
         },
         {
-          label: 'uptime 30m',
+          label: "uptime 30m",
           value: (e) =>
-            e.uptime_last_30m != null ? Number(e.uptime_last_30m).toFixed(1) + '%' : ''
+            e.uptime_last_30m != null ? Number(e.uptime_last_30m).toFixed(1) + "%" : "",
         },
-        { label: 'quant', value: (e) => e.quantization || '' }
+        { label: "quant", value: (e) => e.quantization || "" },
       ]);
     });
     return 0;
   }
 
-  if (sub === 'user') {
+  if (sub === "user") {
     const { values } = parseArgs(rest, {
-      workspace: { type: 'string' }
+      workspace: { type: "string" },
     });
     if (values.help) {
       process.stdout.write(
-        'Usage: openrouter models user [--workspace <id|slug>]\n\nList models filtered by your workspace provider preferences, privacy, and guardrails.\n'
+        "Usage: openrouter models user [--workspace <id|slug>]\n\nList models filtered by your workspace provider preferences, privacy, and guardrails.\n",
       );
       return 0;
     }
     const query = {};
     if (values.workspace) query.workspace_id = values.workspace;
-    const data = await api('GET', '/models/user', {
+    const data = await api("GET", "/models/user", {
       auth: authFromValues(values),
-      query
+      query,
     });
     printResult(data, () => listFormatter(data));
     return 0;
   }
 
-  if (sub === 'count') {
+  if (sub === "count") {
     const { values } = parseArgs(rest, {});
-    const data = await api('GET', '/models/count', {
+    const data = await api("GET", "/models/count", {
       auth: authFromValues(values),
-      requireAuth: false
+      requireAuth: false,
     });
     printResult(data, () => outln(JSON.stringify(data)));
     return 0;
   }
 
   const { values } = parseArgs(rest, {
-    category: { type: 'string' },
-    supported: { type: 'string' },
-    'output-modalities': { type: 'string' },
-    filter: { type: 'string' },
-    free: { type: 'boolean' },
-    sort: { type: 'string' }
+    category: { type: "string" },
+    supported: { type: "string" },
+    "output-modalities": { type: "string" },
+    filter: { type: "string" },
+    free: { type: "boolean" },
+    sort: { type: "string" },
   });
   if (values.help) {
     process.stdout.write(HELP);
@@ -305,37 +314,32 @@ export async function modelsCommand(argv) {
   const query = {};
   if (values.category) query.category = values.category;
   if (values.supported) query.supported_parameters = values.supported;
-  if (values['output-modalities'])
-    query.output_modalities = values['output-modalities'];
+  if (values["output-modalities"]) query.output_modalities = values["output-modalities"];
 
-  const data = await api('GET', '/models', {
+  const data = await api("GET", "/models", {
     auth: authFromValues(values),
     query,
-    requireAuth: false
+    requireAuth: false,
   });
 
   let rows = data.data || [];
   if (values.filter) {
     const f = values.filter.toLowerCase();
     rows = rows.filter(
-      (m) =>
-        (m.id || '').toLowerCase().includes(f) ||
-        (m.name || '').toLowerCase().includes(f)
+      (m) => (m.id || "").toLowerCase().includes(f) || (m.name || "").toLowerCase().includes(f),
     );
   }
-  if (values.free) rows = rows.filter((m) => (m.id || '').endsWith(':free'));
+  if (values.free) rows = rows.filter((m) => (m.id || "").endsWith(":free"));
 
   if (values.sort) {
     const key = values.sort;
     if (!MODEL_SORT_FIELDS.includes(key)) {
-      throw new Error(
-        `Unknown --sort field "${key}". Expected: ${MODEL_SORT_FIELDS.join(' | ')}`
-      );
+      throw new Error(`Unknown --sort field "${key}". Expected: ${MODEL_SORT_FIELDS.join(" | ")}`);
     }
     // Unparseable or missing values must score to a definite extreme, or the
     // comparator reports them equal to everything and the sort is a no-op.
     const num = (x) => {
-      if (x == null || x === '') return null;
+      if (x == null || x === "") return null;
       const n = Number(x);
       return Number.isFinite(n) ? n : null;
     };
@@ -346,15 +350,21 @@ export async function modelsCommand(argv) {
     };
     const get = (m) => {
       switch (key) {
-        case 'id': return m.id || '';
-        case 'name': return m.name || '';
-        case 'context': return desc(m.context_length);
-        case 'prompt': return asc(m.pricing?.prompt);
-        case 'completion': return asc(m.pricing?.completion);
+        case "id":
+          return m.id || "";
+        case "name":
+          return m.name || "";
+        case "context":
+          return desc(m.context_length);
+        case "prompt":
+          return asc(m.pricing?.prompt);
+        case "completion":
+          return asc(m.pricing?.completion);
       }
     };
     rows = [...rows].sort((a, b) => {
-      const va = get(a), vb = get(b);
+      const va = get(a),
+        vb = get(b);
       if (va < vb) return -1;
       if (va > vb) return 1;
       return 0;
@@ -369,23 +379,23 @@ export async function modelsCommand(argv) {
 export async function providersCommand(argv) {
   const { values } = parseArgs(argv, {});
   if (values.help) {
-    process.stdout.write('Usage: openrouter providers\n\nList all providers.\n');
+    process.stdout.write("Usage: openrouter providers\n\nList all providers.\n");
     return 0;
   }
-  const data = await api('GET', '/providers', {
+  const data = await api("GET", "/providers", {
     auth: authFromValues(values),
-    requireAuth: false
+    requireAuth: false,
   });
   printResult(data, () => {
     const rows = data.data || [];
     table(rows, [
-      { label: 'slug', value: (p) => p.slug || p.id || '' },
-      { label: 'name', value: (p) => p.name || '' },
-      { label: 'hq', value: (p) => p.headquarters || '' },
-      { label: 'datacenters', value: (p) => (p.datacenters || []).join(',') || '' },
-      { label: 'privacy', value: (p) => (p.privacy_policy_url ? 'yes' : '') },
-      { label: 'tos', value: (p) => (p.terms_of_service_url ? 'yes' : '') },
-      { label: 'status', value: (p) => (p.status_page_url ? 'yes' : '') }
+      { label: "slug", value: (p) => p.slug || p.id || "" },
+      { label: "name", value: (p) => p.name || "" },
+      { label: "hq", value: (p) => p.headquarters || "" },
+      { label: "datacenters", value: (p) => (p.datacenters || []).join(",") || "" },
+      { label: "privacy", value: (p) => (p.privacy_policy_url ? "yes" : "") },
+      { label: "tos", value: (p) => (p.terms_of_service_url ? "yes" : "") },
+      { label: "status", value: (p) => (p.status_page_url ? "yes" : "") },
     ]);
   });
   return 0;

--- a/src/commands/request.js
+++ b/src/commands/request.js
@@ -1,7 +1,7 @@
-import { stdin } from 'node:process';
-import { parseArgs, authFromValues } from '../args.js';
-import { api } from '../api.js';
-import { printJSON, out } from '../output.js';
+import { stdin } from "node:process";
+import { parseArgs, authFromValues } from "../args.js";
+import { api } from "../api.js";
+import { printJSON, out } from "../output.js";
 
 const HELP = `Usage: openrouter request <METHOD> <path> [options]
 
@@ -21,27 +21,27 @@ Options:
 `;
 
 async function readStdin() {
-  let data = '';
+  let data = "";
   for await (const chunk of stdin) data += chunk;
   return data;
 }
 
 async function loadBody(value) {
-  if (value === '-') return JSON.parse(await readStdin());
-  if (value.startsWith('@')) {
-    const { readFile } = await import('node:fs/promises');
-    return JSON.parse(await readFile(value.slice(1), 'utf8'));
+  if (value === "-") return JSON.parse(await readStdin());
+  if (value.startsWith("@")) {
+    const { readFile } = await import("node:fs/promises");
+    return JSON.parse(await readFile(value.slice(1), "utf8"));
   }
   return JSON.parse(value);
 }
 
 export async function requestCommand(argv) {
   const { values, positionals } = parseArgs(argv, {
-    body: { type: 'string' },
-    query: { type: 'string', multiple: true },
-    header: { type: 'string', multiple: true },
-    binary: { type: 'string' },
-    raw: { type: 'boolean' }
+    body: { type: "string" },
+    query: { type: "string", multiple: true },
+    header: { type: "string", multiple: true },
+    binary: { type: "string" },
+    raw: { type: "boolean" },
   });
   if (values.help) {
     process.stdout.write(HELP);
@@ -56,13 +56,13 @@ export async function requestCommand(argv) {
 
   const query = {};
   for (const q of values.query || []) {
-    const i = q.indexOf('=');
+    const i = q.indexOf("=");
     if (i === -1) throw new Error(`bad --query (need k=v): ${q}`);
     query[q.slice(0, i)] = q.slice(i + 1);
   }
   const headers = {};
   for (const h of values.header || []) {
-    const i = h.indexOf(':');
+    const i = h.indexOf(":");
     if (i === -1) throw new Error(`bad --header (need k:v): ${h}`);
     headers[h.slice(0, i).trim()] = h.slice(i + 1).trim();
   }
@@ -70,16 +70,16 @@ export async function requestCommand(argv) {
   const opts = {
     auth: authFromValues(values),
     headers,
-    query: Object.keys(query).length ? query : undefined
+    query: Object.keys(query).length ? query : undefined,
   };
   if (values.body !== undefined) opts.body = await loadBody(values.body);
 
   if (values.binary) {
     opts.binary = true;
     const bytes = await api(method, path, opts);
-    if (values.binary === '-') process.stdout.write(Buffer.from(bytes));
+    if (values.binary === "-") process.stdout.write(Buffer.from(bytes));
     else {
-      const { writeFile } = await import('node:fs/promises');
+      const { writeFile } = await import("node:fs/promises");
       await writeFile(values.binary, Buffer.from(bytes));
     }
     return 0;
@@ -94,7 +94,7 @@ export async function requestCommand(argv) {
 
   const data = await api(method, path, opts);
   if (data == null) return 0;
-  if (typeof data === 'string') out(data);
+  if (typeof data === "string") out(data);
   else printJSON(data);
   return 0;
 }

--- a/src/commands/rerank.js
+++ b/src/commands/rerank.js
@@ -1,7 +1,7 @@
-import { stdin } from 'node:process';
-import { parseArgs, authFromValues, numberOption } from '../args.js';
-import { api } from '../api.js';
-import { c, outln, printResult } from '../output.js';
+import { stdin } from "node:process";
+import { parseArgs, authFromValues, numberOption } from "../args.js";
+import { api } from "../api.js";
+import { c, outln, printResult } from "../output.js";
 
 const HELP = `Usage: openrouter rerank --model <id> --query <q> [doc...] [options]
 
@@ -17,56 +17,64 @@ Options:
 `;
 
 async function readDocsFromStdin() {
-  let data = '';
+  let data = "";
   for await (const chunk of stdin) data += chunk;
-  return data.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+  return data
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter(Boolean);
 }
 
 export async function rerankCommand(argv) {
   const { values, positionals } = parseArgs(argv, {
-    model: { type: 'string', short: 'm' },
-    query: { type: 'string' },
-    doc: { type: 'string', short: 'd', multiple: true },
-    'docs-file': { type: 'string' },
-    'top-n': { type: 'string' },
-    provider: { type: 'string' }
+    model: { type: "string", short: "m" },
+    query: { type: "string" },
+    doc: { type: "string", short: "d", multiple: true },
+    "docs-file": { type: "string" },
+    "top-n": { type: "string" },
+    provider: { type: "string" },
   });
   if (values.help) {
     process.stdout.write(HELP);
     return 0;
   }
-  if (!values.model) throw new Error('--model is required');
-  if (!values.query) throw new Error('--query is required');
+  if (!values.model) throw new Error("--model is required");
+  if (!values.query) throw new Error("--query is required");
 
   let docs = [...(values.doc || []), ...positionals];
-  if (values['docs-file']) {
-    if (values['docs-file'] === '-') docs = docs.concat(await readDocsFromStdin());
+  if (values["docs-file"]) {
+    if (values["docs-file"] === "-") docs = docs.concat(await readDocsFromStdin());
     else {
-      const { readFile } = await import('node:fs/promises');
-      const text = await readFile(values['docs-file'], 'utf8');
-      docs = docs.concat(text.split(/\r?\n/).map((l) => l.trim()).filter(Boolean));
+      const { readFile } = await import("node:fs/promises");
+      const text = await readFile(values["docs-file"], "utf8");
+      docs = docs.concat(
+        text
+          .split(/\r?\n/)
+          .map((l) => l.trim())
+          .filter(Boolean),
+      );
     }
   }
-  if (!docs.length) throw new Error('No documents. Pass via positionals, --doc, or --docs-file.');
+  if (!docs.length) throw new Error("No documents. Pass via positionals, --doc, or --docs-file.");
 
   const body = {
     model: values.model,
     query: values.query,
-    documents: docs
+    documents: docs,
   };
-  if (values['top-n']) body.top_n = numberOption(values['top-n'], '--top-n');
+  if (values["top-n"]) body.top_n = numberOption(values["top-n"], "--top-n");
   if (values.provider) body.provider = JSON.parse(values.provider);
 
-  const data = await api('POST', '/rerank', {
+  const data = await api("POST", "/rerank", {
     auth: authFromValues(values),
-    body
+    body,
   });
   printResult(data, () => {
     const results = data.results || data.data || [];
     for (const r of results) {
       const idx = r.index;
       const score = r.relevance_score ?? r.score;
-      const text = (r.document && r.document.text) || docs[idx] || '';
+      const text = (r.document && r.document.text) || docs[idx] || "";
       outln(`${c.bold(score?.toFixed?.(4) ?? score)}  ${c.dim(`#${idx}`)}  ${text.slice(0, 120)}`);
     }
   });

--- a/src/commands/speech.js
+++ b/src/commands/speech.js
@@ -1,6 +1,6 @@
-import { parseArgs, authFromValues, numberOption, readStdinIfPiped } from '../args.js';
-import { api } from '../api.js';
-import { writeBinaryOutput } from '../output.js';
+import { parseArgs, authFromValues, numberOption, readStdinIfPiped } from "../args.js";
+import { api } from "../api.js";
+import { writeBinaryOutput } from "../output.js";
 
 const HELP = `Usage: openrouter speech [text...] [options]
 
@@ -17,37 +17,37 @@ Options:
 
 export async function speechCommand(argv) {
   const { values, positionals } = parseArgs(argv, {
-    model: { type: 'string', short: 'm' },
-    voice: { type: 'string' },
-    format: { type: 'string' },
-    speed: { type: 'string' },
-    out: { type: 'string', short: 'o' },
-    provider: { type: 'string' }
+    model: { type: "string", short: "m" },
+    voice: { type: "string" },
+    format: { type: "string" },
+    speed: { type: "string" },
+    out: { type: "string", short: "o" },
+    provider: { type: "string" },
   });
   if (values.help) {
     process.stdout.write(HELP);
     return 0;
   }
-  if (!values.model) throw new Error('--model is required');
+  if (!values.model) throw new Error("--model is required");
 
-  let text = positionals.join(' ').trim();
+  let text = positionals.join(" ").trim();
   const piped = await readStdinIfPiped();
   if (piped) text = text ? `${text}\n${piped}` : piped;
-  if (!text) throw new Error('No input text.');
+  if (!text) throw new Error("No input text.");
 
   const body = { model: values.model, input: text };
   if (values.voice) body.voice = values.voice;
   if (values.format) body.response_format = values.format;
-  if (values.speed) body.speed = numberOption(values.speed, '--speed');
+  if (values.speed) body.speed = numberOption(values.speed, "--speed");
   if (values.provider) body.provider = JSON.parse(values.provider);
 
-  const bytes = await api('POST', '/audio/speech', {
+  const bytes = await api("POST", "/audio/speech", {
     auth: authFromValues(values),
     body,
-    binary: true
+    binary: true,
   });
 
-  const out = values.out || `out.${values.format || 'mp3'}`;
+  const out = values.out || `out.${values.format || "mp3"}`;
   await writeBinaryOutput(bytes, out);
   return 0;
 }

--- a/src/commands/video.js
+++ b/src/commands/video.js
@@ -1,9 +1,9 @@
-import { parseArgs, authFromValues, numberOption } from '../args.js';
-import { api } from '../api.js';
-import { c, info, outln, printResult, writeBinaryOutput } from '../output.js';
+import { parseArgs, authFromValues, numberOption } from "../args.js";
+import { api } from "../api.js";
+import { c, info, outln, printResult, writeBinaryOutput } from "../output.js";
 
-const FAILED_STATUSES = ['failed', 'cancelled', 'error'];
-const TERMINAL_STATUSES = ['succeeded', 'completed', ...FAILED_STATUSES];
+const FAILED_STATUSES = ["failed", "cancelled", "error"];
+const TERMINAL_STATUSES = ["succeeded", "completed", ...FAILED_STATUSES];
 
 const HELP = `Usage: openrouter video <subcommand> [options]
 
@@ -35,74 +35,74 @@ export async function videoCommand(argv) {
   const sub = argv[0];
   const rest = argv.slice(1);
 
-  if (!sub || sub === '-h' || sub === '--help' || sub === 'help') {
+  if (!sub || sub === "-h" || sub === "--help" || sub === "help") {
     process.stdout.write(HELP);
     return sub ? 0 : 1;
   }
 
-  if (rest.includes('-h') || rest.includes('--help')) {
+  if (rest.includes("-h") || rest.includes("--help")) {
     process.stdout.write(HELP);
     return 0;
   }
 
-  if (sub === 'models') {
+  if (sub === "models") {
     const { values } = parseArgs(rest, {});
-    const data = await api('GET', '/videos/models', { auth: authFromValues(values) });
+    const data = await api("GET", "/videos/models", { auth: authFromValues(values) });
     printResult(data);
     return 0;
   }
 
-  if (sub === 'create') {
+  if (sub === "create") {
     const { values, positionals } = parseArgs(rest, {
-      model: { type: 'string', short: 'm' },
-      prompt: { type: 'string', short: 'p' },
-      duration: { type: 'string' },
-      aspect: { type: 'string' },
-      provider: { type: 'string' },
-      extra: { type: 'string' }
+      model: { type: "string", short: "m" },
+      prompt: { type: "string", short: "p" },
+      duration: { type: "string" },
+      aspect: { type: "string" },
+      provider: { type: "string" },
+      extra: { type: "string" },
     });
-    if (!values.model) throw new Error('--model is required');
-    const prompt = values.prompt || positionals.join(' ').trim();
-    if (!prompt) throw new Error('Prompt is required');
+    if (!values.model) throw new Error("--model is required");
+    const prompt = values.prompt || positionals.join(" ").trim();
+    if (!prompt) throw new Error("Prompt is required");
     const body = { model: values.model, prompt };
-    if (values.duration) body.duration = numberOption(values.duration, '--duration');
+    if (values.duration) body.duration = numberOption(values.duration, "--duration");
     if (values.aspect) body.aspect_ratio = values.aspect;
     if (values.provider) body.provider = JSON.parse(values.provider);
     if (values.extra) Object.assign(body, JSON.parse(values.extra));
 
-    const data = await api('POST', '/videos', { auth: authFromValues(values), body });
+    const data = await api("POST", "/videos", { auth: authFromValues(values), body });
     printResult(data, () => {
       const id = data.id || data.job_id || (data.data && data.data.id);
-      outln(`${c.bold('job:')} ${id}`);
+      outln(`${c.bold("job:")} ${id}`);
       outln(JSON.stringify(data, null, 2));
     });
     return 0;
   }
 
-  if (sub === 'get') {
+  if (sub === "get") {
     const { values, positionals } = parseArgs(rest, {});
-    if (!positionals[0]) throw new Error('jobId required');
-    const data = await api('GET', `/videos/${encodeURIComponent(positionals[0])}`, {
-      auth: authFromValues(values)
+    if (!positionals[0]) throw new Error("jobId required");
+    const data = await api("GET", `/videos/${encodeURIComponent(positionals[0])}`, {
+      auth: authFromValues(values),
     });
     printResult(data);
     return 0;
   }
 
-  if (sub === 'wait') {
+  if (sub === "wait") {
     const { values, positionals } = parseArgs(rest, {
-      interval: { type: 'string' },
-      timeout: { type: 'string' }
+      interval: { type: "string" },
+      timeout: { type: "string" },
     });
-    if (!positionals[0]) throw new Error('jobId required');
-    const interval = (numberOption(values.interval, '--interval') ?? 5) * 1000;
-    const timeout = (numberOption(values.timeout, '--timeout') ?? 600) * 1000;
-    if (interval <= 0) throw new Error('--interval must be greater than 0');
-    if (timeout <= 0) throw new Error('--timeout must be greater than 0');
+    if (!positionals[0]) throw new Error("jobId required");
+    const interval = (numberOption(values.interval, "--interval") ?? 5) * 1000;
+    const timeout = (numberOption(values.timeout, "--timeout") ?? 600) * 1000;
+    if (interval <= 0) throw new Error("--interval must be greater than 0");
+    if (timeout <= 0) throw new Error("--timeout must be greater than 0");
     const start = Date.now();
     while (true) {
-      const data = await api('GET', `/videos/${encodeURIComponent(positionals[0])}`, {
-        auth: authFromValues(values)
+      const data = await api("GET", `/videos/${encodeURIComponent(positionals[0])}`, {
+        auth: authFromValues(values),
       });
       const status = data.status || (data.data && data.data.status);
       info(`status: ${status}`);
@@ -111,20 +111,20 @@ export async function videoCommand(argv) {
         return FAILED_STATUSES.includes(status) ? 4 : 0;
       }
       if (Date.now() - start > timeout) {
-        throw new Error('timeout waiting for job');
+        throw new Error("timeout waiting for job");
       }
       await sleep(interval);
     }
   }
 
-  if (sub === 'download') {
+  if (sub === "download") {
     const { values, positionals } = parseArgs(rest, {
-      out: { type: 'string', short: 'o' }
+      out: { type: "string", short: "o" },
     });
-    if (!positionals[0]) throw new Error('jobId required');
-    const bytes = await api('GET', `/videos/${encodeURIComponent(positionals[0])}/content`, {
+    if (!positionals[0]) throw new Error("jobId required");
+    const bytes = await api("GET", `/videos/${encodeURIComponent(positionals[0])}/content`, {
       auth: authFromValues(values),
-      binary: true
+      binary: true,
     });
     const out = values.out || `${positionals[0]}.mp4`;
     await writeBinaryOutput(bytes, out);

--- a/src/commands/workspaces.js
+++ b/src/commands/workspaces.js
@@ -1,6 +1,6 @@
-import { parseArgs, authFromValues, PAGINATION_OPTIONS, paginationQuery } from '../args.js';
-import { api } from '../api.js';
-import { outln, printResult, table } from '../output.js';
+import { parseArgs, authFromValues, PAGINATION_OPTIONS, paginationQuery } from "../args.js";
+import { api } from "../api.js";
+import { outln, printResult, table } from "../output.js";
 
 const HELP = `Usage: openrouter workspaces <subcommand> [options]
 
@@ -25,118 +25,122 @@ create / update options:
 `;
 
 const COMMON = {
-  slug: { type: 'string' },
-  description: { type: 'string' },
-  'default-text-model': { type: 'string' },
-  'default-image-model': { type: 'string' },
-  'default-provider-sort': { type: 'string' }
+  slug: { type: "string" },
+  description: { type: "string" },
+  "default-text-model": { type: "string" },
+  "default-image-model": { type: "string" },
+  "default-provider-sort": { type: "string" },
 };
 
 function buildBody(values) {
   const body = {};
   if (values.slug !== undefined) body.slug = values.slug;
   if (values.description !== undefined) body.description = values.description;
-  if (values['default-text-model'] !== undefined) body.default_text_model = values['default-text-model'];
-  if (values['default-image-model'] !== undefined) body.default_image_model = values['default-image-model'];
-  if (values['default-provider-sort'] !== undefined) body.default_provider_sort = values['default-provider-sort'];
+  if (values["default-text-model"] !== undefined)
+    body.default_text_model = values["default-text-model"];
+  if (values["default-image-model"] !== undefined)
+    body.default_image_model = values["default-image-model"];
+  if (values["default-provider-sort"] !== undefined)
+    body.default_provider_sort = values["default-provider-sort"];
   return body;
 }
 
 export async function workspacesCommand(argv) {
   const sub = argv[0];
   const rest = argv.slice(1);
-  if (!sub || sub === 'help' || sub === '-h' || sub === '--help') {
+  if (!sub || sub === "help" || sub === "-h" || sub === "--help") {
     process.stdout.write(HELP);
     return sub ? 0 : 1;
   }
 
-  if (rest.includes('-h') || rest.includes('--help')) {
+  if (rest.includes("-h") || rest.includes("--help")) {
     process.stdout.write(HELP);
     return 0;
   }
 
-  if (sub === 'list') {
+  if (sub === "list") {
     const { values } = parseArgs(rest, PAGINATION_OPTIONS);
     const query = paginationQuery(values);
-    const data = await api('GET', '/workspaces', {
+    const data = await api("GET", "/workspaces", {
       auth: authFromValues(values),
       requiresManagement: true,
-      query
+      query,
     });
     printResult(data, () => {
       const rows = data.data || [];
       table(rows, [
-        { label: 'slug', value: (w) => w.slug || '' },
-        { label: 'name', value: (w) => w.name || '' },
-        { label: 'id', value: (w) => w.id || '' },
-        { label: 'is_default', value: (w) => (w.is_default ? 'yes' : '') }
+        { label: "slug", value: (w) => w.slug || "" },
+        { label: "name", value: (w) => w.name || "" },
+        { label: "id", value: (w) => w.id || "" },
+        { label: "is_default", value: (w) => (w.is_default ? "yes" : "") },
       ]);
     });
     return 0;
   }
 
-  if (sub === 'get') {
+  if (sub === "get") {
     const { values, positionals } = parseArgs(rest, {});
-    if (!positionals[0]) throw new Error('id|slug required');
-    const data = await api('GET', `/workspaces/${encodeURIComponent(positionals[0])}`, {
+    if (!positionals[0]) throw new Error("id|slug required");
+    const data = await api("GET", `/workspaces/${encodeURIComponent(positionals[0])}`, {
       auth: authFromValues(values),
-      requiresManagement: true
+      requiresManagement: true,
     });
     printResult(data);
     return 0;
   }
 
-  if (sub === 'create') {
+  if (sub === "create") {
     const { values, positionals } = parseArgs(rest, COMMON);
     const name = positionals[0];
-    if (!name) throw new Error('name required');
+    if (!name) throw new Error("name required");
     const body = { name, ...buildBody(values) };
-    const data = await api('POST', '/workspaces', {
+    const data = await api("POST", "/workspaces", {
       auth: authFromValues(values),
       requiresManagement: true,
-      body
+      body,
     });
     printResult(data);
     return 0;
   }
 
-  if (sub === 'update') {
-    const { values, positionals } = parseArgs(rest, { ...COMMON, name: { type: 'string' } });
-    if (!positionals[0]) throw new Error('id|slug required');
+  if (sub === "update") {
+    const { values, positionals } = parseArgs(rest, { ...COMMON, name: { type: "string" } });
+    if (!positionals[0]) throw new Error("id|slug required");
     const body = buildBody(values);
     if (values.name) body.name = values.name;
-    const data = await api('PATCH', `/workspaces/${encodeURIComponent(positionals[0])}`, {
+    const data = await api("PATCH", `/workspaces/${encodeURIComponent(positionals[0])}`, {
       auth: authFromValues(values),
       requiresManagement: true,
-      body
+      body,
     });
     printResult(data);
     return 0;
   }
 
-  if (sub === 'delete') {
+  if (sub === "delete") {
     const { values, positionals } = parseArgs(rest, {});
-    if (!positionals[0]) throw new Error('id|slug required');
-    const data = await api('DELETE', `/workspaces/${encodeURIComponent(positionals[0])}`, {
+    if (!positionals[0]) throw new Error("id|slug required");
+    const data = await api("DELETE", `/workspaces/${encodeURIComponent(positionals[0])}`, {
       auth: authFromValues(values),
-      requiresManagement: true
+      requiresManagement: true,
     });
-    printResult(data, () => outln('deleted'));
+    printResult(data, () => outln("deleted"));
     return 0;
   }
 
-  if (sub === 'add-members' || sub === 'remove-members') {
+  if (sub === "add-members" || sub === "remove-members") {
     const { values, positionals } = parseArgs(rest, {});
-    if (positionals.length < 2) throw new Error('Usage: <id|slug> <userId>...');
+    if (positionals.length < 2) throw new Error("Usage: <id|slug> <userId>...");
     const id = positionals[0];
     const userIds = positionals.slice(1);
-    const path = sub === 'add-members'
-      ? `/workspaces/${encodeURIComponent(id)}/members/add`
-      : `/workspaces/${encodeURIComponent(id)}/members/remove`;
-    const data = await api('POST', path, {
+    const path =
+      sub === "add-members"
+        ? `/workspaces/${encodeURIComponent(id)}/members/add`
+        : `/workspaces/${encodeURIComponent(id)}/members/remove`;
+    const data = await api("POST", path, {
       auth: authFromValues(values),
       requiresManagement: true,
-      body: { user_ids: userIds }
+      body: { user_ids: userIds },
     });
     printResult(data);
     return 0;

--- a/src/config.js
+++ b/src/config.js
@@ -1,37 +1,35 @@
-import { promises as fs } from 'node:fs';
-import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { promises as fs } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
-const XDG = process.env.XDG_CONFIG_HOME || join(homedir(), '.config');
-const CONFIG_DIR = join(XDG, 'openrouter');
-const CONFIG_FILE = join(CONFIG_DIR, 'config.json');
+const XDG = process.env.XDG_CONFIG_HOME || join(homedir(), ".config");
+const CONFIG_DIR = join(XDG, "openrouter");
+const CONFIG_FILE = join(CONFIG_DIR, "config.json");
 
-export const DEFAULT_BASE_URL = 'https://openrouter.ai/api/v1';
-export const DEFAULT_AUTH_URL = 'https://openrouter.ai/auth';
-export const PROVISIONING_KEYS_URL =
-  'https://openrouter.ai/settings/provisioning-keys';
+export const DEFAULT_BASE_URL = "https://openrouter.ai/api/v1";
+export const DEFAULT_AUTH_URL = "https://openrouter.ai/auth";
+export const PROVISIONING_KEYS_URL = "https://openrouter.ai/settings/provisioning-keys";
 
 export async function loadConfig() {
   try {
-    const raw = await fs.readFile(CONFIG_FILE, 'utf8');
+    const raw = await fs.readFile(CONFIG_FILE, "utf8");
     return JSON.parse(raw);
   } catch (err) {
-    if (err.code === 'ENOENT') return {};
+    if (err.code === "ENOENT") return {};
     throw err;
   }
 }
 
 export async function saveConfig(cfg) {
   await fs.mkdir(CONFIG_DIR, { recursive: true, mode: 0o700 });
-  const tmp = CONFIG_FILE + '.tmp';
+  const tmp = CONFIG_FILE + ".tmp";
   await fs.writeFile(tmp, JSON.stringify(cfg, null, 2), { mode: 0o600 });
   await fs.rename(tmp, CONFIG_FILE);
 }
 
 export async function resolveAuth(opts = {}) {
   const cfg = await loadConfig();
-  const userKey =
-    process.env.OPENROUTER_API_KEY || process.env.OPENROUTER_KEY || cfg.apiKey;
+  const userKey = process.env.OPENROUTER_API_KEY || process.env.OPENROUTER_KEY || cfg.apiKey;
   const mgmtKey = process.env.OPENROUTER_MANAGEMENT_KEY || cfg.managementKey;
 
   // If the caller explicitly passed --key, that always wins.
@@ -48,23 +46,19 @@ export async function resolveAuth(opts = {}) {
   }
 
   const baseUrl =
-    opts.baseUrl ||
-    process.env.OPENROUTER_BASE_URL ||
-    cfg.baseUrl ||
-    DEFAULT_BASE_URL;
+    opts.baseUrl || process.env.OPENROUTER_BASE_URL || cfg.baseUrl || DEFAULT_BASE_URL;
   const referer =
     opts.referer ||
     process.env.OPENROUTER_REFERER ||
     cfg.referer ||
-    'https://github.com/aaronjmars/openroutercli';
-  const title =
-    opts.title || process.env.OPENROUTER_TITLE || cfg.title || 'openrouter-cli';
+    "https://github.com/aaronjmars/openroutercli";
+  const title = opts.title || process.env.OPENROUTER_TITLE || cfg.title || "openrouter-cli";
   return {
     apiKey,
     baseUrl,
     referer,
     title,
     hasManagementKey: !!mgmtKey,
-    hasUserKey: !!userKey
+    hasUserKey: !!userKey,
   };
 }

--- a/src/output.js
+++ b/src/output.js
@@ -1,20 +1,16 @@
-import { writeFile } from 'node:fs/promises';
+import { writeFile } from "node:fs/promises";
 
 const isTTY = process.stdout.isTTY;
-const noColor =
-  process.env.NO_COLOR != null ||
-  process.env.OPENROUTER_NO_COLOR != null ||
-  !isTTY;
+const noColor = process.env.NO_COLOR != null || process.env.OPENROUTER_NO_COLOR != null || !isTTY;
 
-const wrap = (open, close) => (s) =>
-  noColor ? String(s) : `\x1b[${open}m${s}\x1b[${close}m`;
+const wrap = (open, close) => (s) => (noColor ? String(s) : `\x1b[${open}m${s}\x1b[${close}m`);
 
 export const c = {
   bold: wrap(1, 22),
   dim: wrap(2, 22),
   red: wrap(31, 39),
   green: wrap(32, 39),
-  cyan: wrap(36, 39)
+  cyan: wrap(36, 39),
 };
 
 let JSON_MODE = false;
@@ -34,27 +30,27 @@ export function out(text) {
   process.stdout.write(text);
 }
 
-export function outln(text = '') {
-  process.stdout.write(text + '\n');
+export function outln(text = "") {
+  process.stdout.write(text + "\n");
 }
 
 export function info(text) {
   if (QUIET || JSON_MODE) return;
-  process.stderr.write(c.dim(text) + '\n');
+  process.stderr.write(c.dim(text) + "\n");
 }
 
 export function printJSON(data) {
-  process.stdout.write(JSON.stringify(data, null, 2) + '\n');
+  process.stdout.write(JSON.stringify(data, null, 2) + "\n");
 }
 
 // OpenRouter prices are per-token; tables show them per million.
 export function pricePerMillion(x) {
-  return x == null ? '-' : (Number(x) * 1e6).toFixed(2);
+  return x == null ? "-" : (Number(x) * 1e6).toFixed(2);
 }
 
 export async function writeBinaryOutput(bytes, out) {
   const buf = Buffer.from(bytes);
-  if (out === '-') {
+  if (out === "-") {
     process.stdout.write(buf);
     return;
   }
@@ -74,21 +70,12 @@ export function printResult(data, formatter) {
 export function table(rows, columns) {
   if (rows.length === 0) return;
   const widths = columns.map((col) =>
-    Math.max(
-      col.label.length,
-      ...rows.map((r) => String(col.value(r) ?? '').length)
-    )
+    Math.max(col.label.length, ...rows.map((r) => String(col.value(r) ?? "").length)),
   );
-  const header = columns
-    .map((col, i) => c.bold(col.label.padEnd(widths[i])))
-    .join('  ');
+  const header = columns.map((col, i) => c.bold(col.label.padEnd(widths[i]))).join("  ");
   outln(header);
-  outln(columns.map((_, i) => c.dim('-'.repeat(widths[i]))).join('  '));
+  outln(columns.map((_, i) => c.dim("-".repeat(widths[i]))).join("  "));
   for (const row of rows) {
-    outln(
-      columns
-        .map((col, i) => String(col.value(row) ?? '').padEnd(widths[i]))
-        .join('  ')
-    );
+    outln(columns.map((col, i) => String(col.value(row) ?? "").padEnd(widths[i])).join("  "));
   }
 }


### PR DESCRIPTION
## What

Adds the [Biome](https://biomejs.dev/) formatter to the repo in formatter-only mode.

- `@biomejs/biome@^2.5.12` as a dev dependency (generates the first committed `package-lock.json`).
- `biome.json`: formatter only (2-space indent, 100 col). Linter and assist are disabled, and JSON/CSS formatting are off to avoid churn.
- `format` and `format:check` npm scripts.
- A `Format` GitHub Actions workflow that runs `npm ci` then `npm run format:check` on push to `main` and on PRs.
- Reformats the existing JS sources (`bin/` + `src/`) to the Biome style.

## Notes

- Linting stays with whatever is already in place; this only touches formatting.
- A `package-lock.json` did not exist before; installing Biome generated one, which is committed so the CI `npm ci` step is reproducible.
- `npm run format:check` passes locally (21 files, no fixes needed).
